### PR TITLE
22 folderdataset name not showing up in breadcrum after immediately creating file

### DIFF
--- a/frontend/src/actions/file.js
+++ b/frontend/src/actions/file.js
@@ -132,6 +132,16 @@ export function fileCreated(formData, selectedDatasetId){
 	};
 }
 
+export const RESET_CREATE_FILE = "RESET_CREATE_FILE";
+export function resetFileCreated(){
+	return (dispatch) => {
+		dispatch({
+			type: RESET_CREATE_FILE,
+			receivedAt: Date.now(),
+		});
+	};
+}
+
 export const UPDATE_FILE = "UPDATE_FILE";
 export function fileUpdated(formData, fileId){
 	return (dispatch) => {

--- a/frontend/src/components/datasets/Dataset.tsx
+++ b/frontend/src/components/datasets/Dataset.tsx
@@ -51,9 +51,6 @@ export const Dataset = (): JSX.Element => {
 	// search parameters
 	let [searchParams, setSearchParams] = useSearchParams();
 	const folder = searchParams.get("folder");
-	useEffect(() => {
-		const currentParams = Object.fromEntries([...searchParams]);
-	}, [searchParams]);
 
 	// use history hook to redirect/navigate between routes
 	const history = useNavigate();

--- a/frontend/src/components/datasets/Dataset.tsx
+++ b/frontend/src/components/datasets/Dataset.tsx
@@ -53,7 +53,6 @@ export const Dataset = (): JSX.Element => {
 	const folder = searchParams.get("folder");
 	useEffect(() => {
 		const currentParams = Object.fromEntries([...searchParams]);
-		console.log(currentParams); // get new values onchange
 	}, [searchParams]);
 
 	// use history hook to redirect/navigate between routes
@@ -371,7 +370,7 @@ export const Dataset = (): JSX.Element => {
 					<Dialog open={createFileOpen} onClose={() => {
 						setCreateFileOpen(false);
 					}} fullWidth={true}  maxWidth="lg" aria-labelledby="form-dialog">
-						<UploadFile selectedDatasetId={datasetId} selectedDatasetName={datasetName} folderId={folder}/>
+						<UploadFile selectedDatasetId={datasetId} selectedDatasetName={about.name} folderId={folder}/>
 					</Dialog>
 				</div>
 			</div>

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -9,7 +9,7 @@ import {CreateMetadata} from "../metadata/CreateMetadata";
 import {fetchMetadataDefinitions, postFileMetadata} from "../../actions/metadata";
 import {MetadataIn} from "../../openapi/v2";
 import {useNavigate} from "react-router-dom";
-import {fileCreated} from "../../actions/file";
+import {fileCreated, resetFileCreated} from "../../actions/file";
 
 type UploadFileProps ={
 	selectedDatasetId: string|undefined,
@@ -25,6 +25,7 @@ export const UploadFile:React.FC<UploadFileProps> = (props: UploadFileProps) => 
 	const getMetadatDefinitions = (name:string|null, skip:number, limit:number) => dispatch(fetchMetadataDefinitions(name, skip,limit));
 	const createFileMetadata = (fileId: string|undefined, metadata:MetadataIn) => dispatch(postFileMetadata(fileId, metadata));
 	const uploadFile = (formData: FormData, selectedDatasetId: string|undefined) => dispatch(fileCreated(formData, selectedDatasetId));
+	const resetUploadFile = () => dispatch(resetFileCreated());
 	const newFile = useSelector((state:RootState) => state.dataset.newFile);
 
 	useEffect(() => {
@@ -65,12 +66,16 @@ export const UploadFile:React.FC<UploadFileProps> = (props: UploadFileProps) => 
 	useEffect(() => {
 		if (newFile.id) {
 			// post new metadata
+			const file = newFile;
 			Object.keys(metadataRequestForms).map(key => {
-				createFileMetadata(newFile.id, metadataRequestForms[key]);
+				createFileMetadata(file.id, metadataRequestForms[key]);
 			});
 
+			// reset newFile so next upload can be done
+			resetUploadFile();
+
 			// Redirect to file route with file Id and dataset id
-			history(`/files/${newFile.id}?dataset=${selectedDatasetId}&name=${selectedDatasetName}`);
+			history(`/files/${file.id}?dataset=${selectedDatasetId}&name=${selectedDatasetName}`);
 			// TODO dispatch(resetFileUploaded());
 		}
 

--- a/frontend/src/reducers/dataset.ts
+++ b/frontend/src/reducers/dataset.ts
@@ -9,7 +9,7 @@ import {
 	FOLDER_ADDED, RECEIVE_FOLDERS_IN_DATASET, GET_FOLDER_PATH,
 	DOWNLOAD_DATASET
 } from "../actions/dataset";
-import {CREATE_FILE, UPDATE_FILE, DELETE_FILE} from "../actions/file";
+import {CREATE_FILE, UPDATE_FILE, DELETE_FILE, RESET_CREATE_FILE} from "../actions/file";
 import {DataAction} from "../types/action";
 import {Author, Dataset, File, DatasetState} from "../types/data";
 
@@ -42,6 +42,8 @@ const dataset = (state = defaultState, action: DataAction) => {
 		return Object.assign({}, state, {
 			newFile: action.file
 		});
+	case RESET_CREATE_FILE:
+		return Object.assign({}, state, {newFile: {}})
 	case UPDATE_FILE:
 		return Object.assign({}, state, {
 			files: state.files.map(file => file.id === action.file.id ? action.file: file),

--- a/frontend/src/types/action.ts
+++ b/frontend/src/types/action.ts
@@ -2,6 +2,7 @@ import {Dataset, ExtractedMetadata, File, MetadataJsonld, FilePreview, FileVersi
 import {MetadataOut as Metadata, FileOut as FileSummary} from "../openapi/v2";
 import {MetadataDefinitionOut as MetadataDefinition} from "../openapi/v2";
 import {POST_DATASET_METADATA, UPDATE_DATASET_METADATA} from "../actions/metadata";
+import {RESET_CREATE_FILE} from "../actions/file";
 
 interface RECEIVE_FILES_IN_DATASET {
 	type: "RECEIVE_FILES_IN_DATASET";
@@ -81,10 +82,19 @@ interface CREATE_DATASET{
 	type: "CREATE_DATASET",
 	dataset: Dataset
 }
+interface RESET_CREATE_DATASET{
+	type: "RESET_CREATE_DATASET",
+	newDataset: Dataset
+}
 
 interface CREATE_FILE{
 	type: "CREATE_FILE",
-	file: File
+	newFile: File
+}
+
+interface RESET_CREATE_FILE{
+	type: "RESET_CREATE_FILE",
+	newFile: File
 }
 
 interface FAILED{
@@ -170,7 +180,9 @@ export type DataAction =
 	| REGISTER_ERROR
 	| REGISTER_USER
 	| CREATE_DATASET
+	| RESET_CREATE_DATASET
 	| CREATE_FILE
+	| RESET_CREATE_FILE
 	| FAILED
 	| RESET_FAILED
 	| RESET_LOGOUT


### PR DESCRIPTION
<img width="528" alt="image" src="https://user-images.githubusercontent.com/13950475/175144364-8bb64e6d-3ce1-438b-9130-47627781c051.png">
fix the empty dataset name in the breadcrumb when upload new files