### PR TITLE
47 keycloak needs volume to store user data

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -77,6 +77,7 @@ services:
       volumes:
         - ./backend/keycloak/clowder-realm-dev.json:/opt/keycloak/data/import/realm.json:ro
         - ./backend/keycloak/clowder-theme/:/opt/keycloak/themes/clowder-theme/:ro
+        - ./backend/keycloak/data/:/opt/keycloak/data
       command:
         - start-dev
         - --http-relative-path /keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,7 @@ services:
       volumes:
         - ./backend/keycloak/clowder-realm-prod.json:/opt/keycloak/data/import/realm.json:ro
         - ./backend/keycloak/clowder-theme/:/opt/keycloak/themes/clowder-theme/:ro
+        - ./backend/keycloak/data/:/opt/keycloak/data
       command:
         - start-dev
         - --http-relative-path /keycloak


### PR DESCRIPTION
I believe this is now fixed. 

this link on stackoverflow

https://stackoverflow.com/questions/59681041/how-to-take-db-backup-in-keycloak-docker-container/60554189#60554189

had a suggestion which I used and now, when I do docker-dev.sh down and up, the users are still in keycloak. 

If someone else can test to confirm.

Made the change in docker-compose.yml and docker-compose.dev.yml.