### PR TITLE
url to link to the correct repo

### DIFF
--- a/frontend/src/app.config.ts
+++ b/frontend/src/app.config.ts
@@ -22,7 +22,7 @@ config["apikey"] = apikey;
 
 V2.OpenAPI.BASE = config.hostname;
 
-config["GHIssueBaseURL"] = "https://github.com/clowder-framework/clowder2-frontend/issues/new?title=%5BClowder+V2%5D";
+config["GHIssueBaseURL"] = "https://github.com/clowder-framework/clowder2/issues/new?title=%5BClowder+V2%5D";
 
 // Backend Keycloak login url
 config["KeycloakBaseURL"] = process.env.KeycloakBaseURL || config.hostname + "/api/v2/auth";


### PR DESCRIPTION
To test, you can shut down the fastapi backend; but still running the frontend. 
Click report it should link to the latest repo now.