### PR TITLE
ensure m1 / arm64 image is pushed to Dockerhub

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           context: ./frontend
           target: clowder-build
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixing oversight from #44, hopefully users can easily use all of Clowder V2 on Apple Silicon M1. 

This fix ensures images are pushed to Dockerhub. 