### PR TITLE
Delete bad JWT token after attempting a refresh to avoid 403 on OPTIO…

### DIFF
--- a/frontend/src/actions/common.js
+++ b/frontend/src/actions/common.js
@@ -32,8 +32,6 @@ export function handleErrors(reason, originalFunc){
 	if (reason.status === 401){
 
 		const headers = {"Authorization": cookies.get("Authorization")};
-		V2.OpenAPI.TOKEN = undefined;
-		cookies.remove("Authorization", { path: "/" });
 
 		return (dispatch) => {
 			return fetch(config.KeycloakRefresh, {method: "GET", headers: headers})
@@ -54,6 +52,9 @@ export function handleErrors(reason, originalFunc){
 						type: LOGOUT,
 						receivedAt: Date.now()
 					});
+					// Delete bad JWT token
+					V2.OpenAPI.TOKEN = undefined;
+					cookies.remove("Authorization", { path: "/" });
 				});
 		};
 	}


### PR DESCRIPTION
…N /refresh_token.

This was happening when the JWT token expired and we were trying to refresh it. It would result in a redirect to always the main page instead of the page we were on.