### PR TITLE
Fix/docker compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -68,7 +68,7 @@ services:
       volumes:
         - postgres_data:/var/lib/postgresql/data
       environment:
-        POSTGRES_DB: keycloak
+        POSTGRES_DB: keycloak_prod
         POSTGRES_USER: keycloak
         POSTGRES_PASSWORD: password
 
@@ -85,7 +85,7 @@ services:
         KEYCLOAK_ADMIN: admin
         KEYCLOAK_ADMIN_PASSWORD: admin
         KC_DB: postgres
-        KC_DB_URL_HOST: postgres
+        KC_DB_URL_HOST: postgres_dev
         KC_DB_URL_DATABASE: keycloak
         KC_DB_USERNAME: keycloak
         KC_DB_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,7 @@ services:
       volumes:
         - postgres_data:/var/lib/postgresql/data
       environment:
-        POSTGRES_DB: keycloak
+        POSTGRES_DB: keycloak_prod
         POSTGRES_USER: keycloak
         POSTGRES_PASSWORD: password
 
@@ -156,7 +156,7 @@ services:
         KEYCLOAK_ADMIN_PASSWORD: admin
         KC_DB: postgres
         KC_DB_URL_HOST: postgres
-        KC_DB_URL_DATABASE: keycloak
+        KC_DB_URL_DATABASE: keycloak_prod
         KC_DB_USERNAME: keycloak
         KC_DB_PASSWORD: password
       depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 version: '3.7'
 
-# Settings and configurations that are common for all containers
+# Settings and configurations that are common for all minio containers
 x-minio-common: &minio-common
   image: quay.io/minio/minio:RELEASE.2022-01-25T19-56-04Z
   command: server --console-address ":9001" http://minio{1...4}/data
+  restart: unless-stopped
   environment:
     MINIO_ROOT_USER: minioadmin
     MINIO_ROOT_PASSWORD: minioadmin
@@ -18,9 +19,8 @@ x-minio-common: &minio-common
 services:
 
   reverse-proxy:
-    # The official v2 Traefik docker image
     image: traefik:v2.5
-    # Enables the web UI and tells Traefik to listen to docker
+    restart: unless-stopped
     command:
       - --api.insecure=true
       - --providers.docker
@@ -38,6 +38,7 @@ services:
 
   backend:
     image: 'clowder/clowder2-backend'
+    restart: unless-stopped
     build:
       context: ./backend
     networks:
@@ -67,6 +68,7 @@ services:
 
   frontend:
     image: "clowder/clowder2-frontend"
+    restart: unless-stopped
     build:
       context: ./frontend
     networks:
@@ -84,6 +86,7 @@ services:
 
   mongo:
     image: mongo:5.0
+    restart: unless-stopped
     networks:
       - clowder2
     volumes:
@@ -118,6 +121,7 @@ services:
 
   minio-nginx:
     image: nginx:1.19.2-alpine
+    restart: unless-stopped
     hostname: nginx
     networks:
       - clowder2
@@ -131,6 +135,7 @@ services:
 
   postgres:
       image: postgres
+      restart: unless-stopped
       networks:
         - clowder2
       volumes:
@@ -142,6 +147,7 @@ services:
 
   keycloak:
       image: quay.io/keycloak/keycloak:19.0
+      restart: unless-stopped
       networks:
         - clowder2
       volumes:
@@ -169,9 +175,9 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.3.3
+    restart: unless-stopped
     networks:
       - clowder2
-    restart: unless-stopped
     environment:
       - "cluster.name=clowder2"
       - "discovery.type=single-node"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     environment:
       MONGODB_URL: mongodb://mongo:27017
       MINIO_SERVER_URL: minio-nginx:9000
-      elasticsearch_url: elasticsearch:9200
+      elasticsearch_url: http://elasticsearch:9200
       auth_base: http://localhost
       auth_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
       oauth2_scheme_auth_url: http://keycloak:8080/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
@@ -58,6 +58,7 @@ services:
       - mongo
       - minio-nginx
       - keycloak
+      - elasticsearch
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.backend.rule=PathPrefix(`/api`)"


### PR DESCRIPTION
Fixed issues with running prod with docker compose.

- fixed elasticsearch URL
- use separate keycloak postgres database for prod and dev. This might require deleting existing volumes `docker compose down -v`
- restart all services if error so that backend can eventually connect to elasticsearch container (which takes a long time to come online)