### PR TITLE
260 show extractor metadata

### DIFF
--- a/.run/uvicorn.run.xml
+++ b/.run/uvicorn.run.xml
@@ -6,9 +6,9 @@
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/.local/share/virtualenvs/clowder2-pkRZ1537/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/backend" />
-    <option name="IS_MODULE_SDK" value="true" />
+    <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />

--- a/.run/uvicorn.run.xml
+++ b/.run/uvicorn.run.xml
@@ -6,9 +6,9 @@
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/.local/share/virtualenvs/clowder2-pkRZ1537/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/backend" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />

--- a/backend/app/models/listeners.py
+++ b/backend/app/models/listeners.py
@@ -18,7 +18,9 @@ class Repository(MongoModel):
 class ExtractorInfo(BaseModel):
     """Currently for extractor_info JSON from Clowder v1 extractors for use with to /api/extractors endpoint."""
 
-    author: Optional[str] # Referring to author of listener script (e.g. name or email), not Clowder user
+    author: Optional[
+        str
+    ]  # Referring to author of listener script (e.g. name or email), not Clowder user
     process: Optional[dict]
     maturity: str = "Development"
     name: Optional[str] = ""

--- a/backend/app/routers/datasets.py
+++ b/backend/app/routers/datasets.py
@@ -830,7 +830,7 @@ async def get_dataset_extract(
             body["parameters"] = parameters
         else:
             parameters = {}
-        current_routing_key =  current_queue
+        current_routing_key = current_queue
 
         submit_dataset_message(
             dataset_out,

--- a/frontend/src/components/datasets/Dataset.tsx
+++ b/frontend/src/components/datasets/Dataset.tsx
@@ -13,6 +13,7 @@ import FilesTable from "../files/FilesTable";
 import config from "../../app.config";
 import {DatasetIn, MetadataIn} from "../../openapi/v2";
 import {DisplayMetadata} from "../metadata/DisplayMetadata";
+import {DisplayListenerMetadata} from "../metadata/DisplayListenerMetadata";
 import {EditMetadata} from "../metadata/EditMetadata";
 import {
 	deleteDatasetMetadata as deleteDatasetMetadataAction,
@@ -188,6 +189,9 @@ export const Dataset = (): JSX.Element => {
 							 label="Metadata" {...a11yProps(1)} disabled={false}/>
 						 <Tab icon={<AssessmentIcon/>} iconPosition="start" sx={tab}
 							 label="Extractors" {...a11yProps(2)} disabled={false}/>
+						<Tab icon={<AssessmentIcon/>} iconPosition="start" sx={tab}
+							 label="Extractor Metadata" {...a11yProps(3)} disabled={false}/>
+
 					</Tabs>
 					<TabPanel value={selectedTabIndex} index={0}>
 						<FilesTable datasetId={datasetId} folderId={folderId}/>
@@ -229,7 +233,11 @@ export const Dataset = (): JSX.Element => {
 							datasetId={datasetId}
 						/>
 					</TabPanel>
-					<TabPanel value={selectedTabIndex} index={3}/>
+							<TabPanel value={selectedTabIndex} index={3}>
+						<DisplayListenerMetadata updateMetadata={updateDatasetMetadata}
+													 deleteMetadata={deleteDatasetMetadata}
+													 resourceType="dataset" resourceId={datasetId}/>
+					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={4}/>
 				</Grid>
 				<Grid item>

--- a/frontend/src/components/datasets/Dataset.tsx
+++ b/frontend/src/components/datasets/Dataset.tsx
@@ -186,11 +186,11 @@ export const Dataset = (): JSX.Element => {
 					<Tabs value={selectedTabIndex} onChange={handleTabChange} aria-label="dataset tabs">
 						<Tab icon={<InsertDriveFile/>} iconPosition="start" sx={tab} label="Files" {...a11yProps(0)} />
 						<Tab icon={<FormatListBulleted/>} iconPosition="start" sx={tab}
-							 label="Metadata" {...a11yProps(1)} disabled={false}/>
+							 label="User Metadata" {...a11yProps(1)} disabled={false}/>
 						 <Tab icon={<AssessmentIcon/>} iconPosition="start" sx={tab}
-							 label="Extractors" {...a11yProps(2)} disabled={false}/>
+							 label="Extracted Metadata" {...a11yProps(2)} disabled={false}/>
 						<Tab icon={<AssessmentIcon/>} iconPosition="start" sx={tab}
-							 label="Extractor Metadata" {...a11yProps(3)} disabled={false}/>
+							 label="Extractors" {...a11yProps(3)} disabled={false}/>
 
 					</Tabs>
 					<TabPanel value={selectedTabIndex} index={0}>
@@ -229,14 +229,14 @@ export const Dataset = (): JSX.Element => {
 						}
 					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={2}>
-						<Listeners
-							datasetId={datasetId}
-						/>
-					</TabPanel>
-							<TabPanel value={selectedTabIndex} index={3}>
 						<DisplayListenerMetadata updateMetadata={updateDatasetMetadata}
 													 deleteMetadata={deleteDatasetMetadata}
 													 resourceType="dataset" resourceId={datasetId}/>
+					</TabPanel>
+					<TabPanel value={selectedTabIndex} index={3}>
+						<Listeners
+							datasetId={datasetId}
+						/>
 					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={4}/>
 				</Grid>

--- a/frontend/src/components/files/File.tsx
+++ b/frontend/src/components/files/File.tsx
@@ -231,9 +231,9 @@ export const File = (): JSX.Element => {
 					<Tabs value={selectedTabIndex} onChange={handleTabChange} aria-label="file tabs">
 						{/*<Tab label="Previews" {...a11yProps(0)} />*/}
 						<Tab label="Version History" {...a11yProps(0)} />
-						<Tab label="Metadata" {...a11yProps(1)} disabled={false}/>
-						<Tab label="Extractors" {...a11yProps(2)} disabled={false}/>
-						<Tab label="Extractor Metadata" {...a11yProps(3)} disabled={false}/>
+						<Tab label="User Metadata" {...a11yProps(1)} disabled={false}/>
+						<Tab label="Extracted Metadata" {...a11yProps(2)} disabled={false}/>
+						<Tab label="Extractors" {...a11yProps(3)} disabled={false}/>
 					</Tabs>
 					{/*Preview Tab*/}
 					{/*<TabPanel value={selectedTabIndex} index={0}>*/}
@@ -287,14 +287,14 @@ export const File = (): JSX.Element => {
 						}
 					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={2}>
-						<Listeners fileId={fileId}
-								   datasetId={datasetId}
-						/>
-					</TabPanel>
-					<TabPanel value={selectedTabIndex} index={3}>
 						<DisplayListenerMetadata updateMetadata={updateFileMetadata}
 													 deleteMetadata={deleteFileMetadata}
 													 resourceType="file" resourceId={fileId}/>
+					</TabPanel>
+					<TabPanel value={selectedTabIndex} index={3}>
+						<Listeners fileId={fileId}
+								   datasetId={datasetId}
+						/>
 					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={4}>
 						Comments

--- a/frontend/src/components/files/File.tsx
+++ b/frontend/src/components/files/File.tsx
@@ -132,6 +132,8 @@ export const File = (): JSX.Element => {
 
 	const setMetadata = (metadata: any) => {
 		// TODO wrap this in to a function
+		console.log('metadata in file component');
+		console.log(metadata);
 		setMetadataRequestForms(prevState => {
 			// merge the contents field; e.g. lat lon
 			if (metadata.definition in prevState) {
@@ -230,6 +232,7 @@ export const File = (): JSX.Element => {
 						<Tab label="Version History" {...a11yProps(0)} />
 						<Tab label="Metadata" {...a11yProps(1)} disabled={false}/>
 						<Tab label="Extractors" {...a11yProps(2)} disabled={false}/>
+						<Tab label="Extractor Metadata" {...a11yProps(3)} disabled={false}/>
 					</Tabs>
 					{/*Preview Tab*/}
 					{/*<TabPanel value={selectedTabIndex} index={0}>*/}
@@ -288,6 +291,9 @@ export const File = (): JSX.Element => {
 						/>
 					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={3}>
+						Extractor Metadata goes here
+					</TabPanel>
+					<TabPanel value={selectedTabIndex} index={4}>
 						Comments
 					</TabPanel>
 				</Grid>

--- a/frontend/src/components/files/File.tsx
+++ b/frontend/src/components/files/File.tsx
@@ -13,6 +13,7 @@ import {MainBreadcrumbs} from "../navigation/BreadCrumb";
 import {ActionModal} from "../dialog/ActionModal";
 import {FileVersionHistory} from "../versions/FileVersionHistory";
 import {DisplayMetadata} from "../metadata/DisplayMetadata";
+import {DisplayListenerMetadata} from "../metadata/DisplayListenerMetadata";
 import {
 	deleteFileMetadata as deleteFileMetadataAction,
 	fetchFileMetadata,
@@ -291,7 +292,9 @@ export const File = (): JSX.Element => {
 						/>
 					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={3}>
-						Extractor Metadata goes here
+						<DisplayListenerMetadata updateMetadata={updateFileMetadata}
+													 deleteMetadata={deleteFileMetadata}
+													 resourceType="file" resourceId={fileId}/>
 					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={4}>
 						Comments

--- a/frontend/src/components/metadata/DisplayListenerMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayListenerMetadata.tsx
@@ -7,12 +7,14 @@ import {fetchDatasetMetadata, fetchFileMetadata, fetchMetadataDefinitions} from 
 import {Agent} from "./Agent";
 import {MetadataDeleteButton} from "./widgets/MetadataDeleteButton";
 import {ListenerMetadataEntry} from "../metadata/ListenerMetadataEntry";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 
 type MetadataType = {
 	updateMetadata: any,
 	deleteMetadata: any,
-	resourceType:string|undefined,
-	resourceId:string|undefined,
+	resourceType: string | undefined,
+	resourceId: string | undefined,
 }
 
 /*
@@ -25,7 +27,7 @@ export const DisplayListenerMetadata = (props: MetadataType) => {
 
 	const dispatch = useDispatch();
 
-	const getMetadatDefinitions = (name:string|null, skip:number, limit:number) => dispatch(fetchMetadataDefinitions(name, skip,limit));
+	const getMetadatDefinitions = (name: string | null, skip: number, limit: number) => dispatch(fetchMetadataDefinitions(name, skip, limit));
 	const metadataDefinitionList = useSelector((state: RootState) => state.metadata.metadataDefinitionList);
 	const listDatasetMetadata = (datasetId: string | undefined) => dispatch(fetchDatasetMetadata(datasetId));
 	const listFileMetadata = (fileId: string | undefined) => dispatch(fetchFileMetadata(fileId));
@@ -38,10 +40,9 @@ export const DisplayListenerMetadata = (props: MetadataType) => {
 
 	// complete metadata list with both definition and values
 	useEffect(() => {
-		if (resourceType === "dataset"){
+		if (resourceType === "dataset") {
 			listDatasetMetadata(resourceId);
-		}
-		else if (resourceType === "file"){
+		} else if (resourceType === "file") {
 			listFileMetadata(resourceId);
 		}
 	}, [resourceType, resourceId]);
@@ -55,25 +56,24 @@ export const DisplayListenerMetadata = (props: MetadataType) => {
 					else if (resourceType === "file") metadataList = fileMetadataList;
 					let listenerMetadataList = [];
 					let listenerMetadataContent = [];
-					return metadataList.map((metadata,idx) => {
+
+					return (<Grid container spacing={2}>
+						{metadataList.map((metadata, idx) => {
 						if (metadata.agent.listener !== null) {
-							return (<Box className="inputGroup" key={idx} sx={{ p: 2, border: '2px solid grey' }}>
-									<Grid>
-										<ListenerMetadataEntry agent={metadata.agent}
+							return (<Grid item xs={12}><Card key={idx}>
+								<CardContent>
+									<ListenerMetadataEntry agent={metadata.agent}
 														   contents={metadata.contents}
-															context={metadata.context}
-															context_url={metadata.context_url}
-															created={metadata.created}
-										/>
-									</Grid>
-
-							</Box>);
-
-
-
+														   context={metadata.context}
+														   context_url={metadata.context_url}
+														   created={metadata.created}
+									/>
+								</CardContent>
+							</Card></Grid>);
 						}
-					});
-				})()
+						})}
+					</Grid>);
+			})()
 			}
 		</>
 	)

--- a/frontend/src/components/metadata/DisplayListenerMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayListenerMetadata.tsx
@@ -57,7 +57,7 @@ export const DisplayListenerMetadata = (props: MetadataType) => {
 					let listenerMetadataContent = [];
 					return metadataList.map((metadata,idx) => {
 						if (metadata.agent.listener !== null) {
-							return (<Box className="inputGroup" key={idx} sx={{ p: 2, border: '1px dashed grey' }}>
+							return (<Box className="inputGroup" key={idx} sx={{ p: 2, border: '2px solid grey' }}>
 									<Grid>
 										<ListenerMetadataEntry agent={metadata.agent}
 														   contents={metadata.contents}

--- a/frontend/src/components/metadata/DisplayListenerMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayListenerMetadata.tsx
@@ -6,6 +6,7 @@ import {RootState} from "../../types/data";
 import {fetchDatasetMetadata, fetchFileMetadata, fetchMetadataDefinitions} from "../../actions/metadata";
 import {Agent} from "./Agent";
 import {MetadataDeleteButton} from "./widgets/MetadataDeleteButton";
+import {ListenerMetadataEntry} from "../metadata/ListenerMetadataEntry";
 
 type MetadataType = {
 	updateMetadata: any,
@@ -53,13 +54,22 @@ export const DisplayListenerMetadata = (props: MetadataType) => {
 					if (resourceType === "dataset") metadataList = datasetMetadataList;
 					else if (resourceType === "file") metadataList = fileMetadataList;
 					let listenerMetadataList = [];
-					metadataList.map((metadata,idx) => {
+					let listenerMetadataContent = [];
+					return metadataList.map((metadata,idx) => {
 						if (metadata.agent.listener !== null) {
-							listenerMetadataList.push(metadata);
+							console.log('listener metadata', metadata);
+							return (<Box className="inputGroup" key={idx}>
+									<ListenerMetadataEntry agent={metadata.agent}
+														   contents={metadata.contents}
+															context={metadata.context}
+															context_url={metadata.context_url}
+															created={metadata.created}
+									/>
+							</Box>);
+
+
 						}
 					});
-					return "nothing yet"
-
 				})()
 			}
 		</>

--- a/frontend/src/components/metadata/DisplayListenerMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayListenerMetadata.tsx
@@ -1,0 +1,67 @@
+import React, {useEffect} from "react";
+import {Box, Grid, Typography} from "@mui/material";
+import {metadataConfig} from "../../metadata.config";
+import {useSelector, useDispatch} from "react-redux";
+import {RootState} from "../../types/data";
+import {fetchDatasetMetadata, fetchFileMetadata, fetchMetadataDefinitions} from "../../actions/metadata";
+import {Agent} from "./Agent";
+import {MetadataDeleteButton} from "./widgets/MetadataDeleteButton";
+
+type MetadataType = {
+	updateMetadata: any,
+	deleteMetadata: any,
+	resourceType:string|undefined,
+	resourceId:string|undefined,
+}
+
+/*
+This is the interface displayed already created metadata and allow eidts
+Uses only the list of metadata
+*/
+export const DisplayListenerMetadata = (props: MetadataType) => {
+
+	const {updateMetadata, deleteMetadata, resourceType, resourceId} = props;
+
+	const dispatch = useDispatch();
+
+	const getMetadatDefinitions = (name:string|null, skip:number, limit:number) => dispatch(fetchMetadataDefinitions(name, skip,limit));
+	const metadataDefinitionList = useSelector((state: RootState) => state.metadata.metadataDefinitionList);
+	const listDatasetMetadata = (datasetId: string | undefined) => dispatch(fetchDatasetMetadata(datasetId));
+	const listFileMetadata = (fileId: string | undefined) => dispatch(fetchFileMetadata(fileId));
+	const datasetMetadataList = useSelector((state: RootState) => state.metadata.datasetMetadataList);
+	const fileMetadataList = useSelector((state: RootState) => state.metadata.fileMetadataList);
+
+	useEffect(() => {
+		getMetadatDefinitions(null, 0, 100);
+	}, []);
+
+	// complete metadata list with both definition and values
+	useEffect(() => {
+		if (resourceType === "dataset"){
+			listDatasetMetadata(resourceId);
+		}
+		else if (resourceType === "file"){
+			listFileMetadata(resourceId);
+		}
+	}, [resourceType, resourceId]);
+
+	return (
+		<>
+			{
+				(() => {
+					let metadataList = [];
+					if (resourceType === "dataset") metadataList = datasetMetadataList;
+					else if (resourceType === "file") metadataList = fileMetadataList;
+					let listenerMetadataList = [];
+					metadataList.map((metadata,idx) => {
+						if (metadata.agent.listener !== null) {
+							listenerMetadataList.push(metadata);
+						}
+					});
+					return "nothing yet"
+
+				})()
+			}
+		</>
+	)
+}

--- a/frontend/src/components/metadata/DisplayListenerMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayListenerMetadata.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {Box, Grid, Typography} from "@mui/material";
 import {metadataConfig} from "../../metadata.config";
 import {useSelector, useDispatch} from "react-redux";
@@ -57,7 +57,7 @@ export const DisplayListenerMetadata = (props: MetadataType) => {
 					let listenerMetadataContent = [];
 					return metadataList.map((metadata,idx) => {
 						if (metadata.agent.listener !== null) {
-							return (<Box className="inputGroup" key={idx}>
+							return (<Box className="inputGroup" key={idx} sx={{ p: 2, border: '1px dashed grey' }}>
 									<Grid>
 										<ListenerMetadataEntry agent={metadata.agent}
 														   contents={metadata.contents}

--- a/frontend/src/components/metadata/DisplayListenerMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayListenerMetadata.tsx
@@ -57,15 +57,18 @@ export const DisplayListenerMetadata = (props: MetadataType) => {
 					let listenerMetadataContent = [];
 					return metadataList.map((metadata,idx) => {
 						if (metadata.agent.listener !== null) {
-							console.log('listener metadata', metadata);
 							return (<Box className="inputGroup" key={idx}>
-									<ListenerMetadataEntry agent={metadata.agent}
+									<Grid>
+										<ListenerMetadataEntry agent={metadata.agent}
 														   contents={metadata.contents}
 															context={metadata.context}
 															context_url={metadata.context_url}
 															created={metadata.created}
-									/>
+										/>
+									</Grid>
+
 							</Box>);
+
 
 
 						}

--- a/frontend/src/components/metadata/ListenerAgent.tsx
+++ b/frontend/src/components/metadata/ListenerAgent.tsx
@@ -15,7 +15,6 @@ export const ListenerAgent = (props) => {
 	const {created, agent} = props;
 	const id = `agent-${agent.id}`;
 	const listener = agent.listener;
-	console.log(listener);
 
 	return (
 		<>

--- a/frontend/src/components/metadata/ListenerAgent.tsx
+++ b/frontend/src/components/metadata/ListenerAgent.tsx
@@ -5,7 +5,7 @@ import {parseDate} from "../../utils/common";
 
 const textStyle = {
 	fontWeight: "normal",
-	fontSize: "10px",
+	fontSize: "16x",
 	fontStyle: "italic",
 	color: theme.palette.secondary.light,
 };

--- a/frontend/src/components/metadata/ListenerAgent.tsx
+++ b/frontend/src/components/metadata/ListenerAgent.tsx
@@ -6,8 +6,7 @@ import {parseDate} from "../../utils/common";
 const textStyle = {
 	fontWeight: "normal",
 	fontSize: "16x",
-	fontStyle: "italic",
-	color: theme.palette.secondary.light,
+	color: theme.palette.primary,
 };
 
 

--- a/frontend/src/components/metadata/ListenerAgent.tsx
+++ b/frontend/src/components/metadata/ListenerAgent.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import {Box, Typography} from "@mui/material";
+import {theme} from "../../theme";
+import {parseDate} from "../../utils/common";
+
+const textStyle = {
+	fontWeight: "normal",
+	fontSize: "10px",
+	fontStyle: "italic",
+	color: theme.palette.secondary.light,
+};
+
+
+export const ListenerAgent = (props) => {
+	const {created, agent} = props;
+	const id = `agent-${agent.id}`;
+	const listener = agent.listener;
+	console.log(listener);
+
+	return (
+		<>
+			<Box key={id}>
+				<Typography sx={textStyle}>Listener name: {agent.listener.name}</Typography>
+				<Typography sx={textStyle}>Version: {agent.listener.version}</Typography>
+				<Typography sx={textStyle}>Created at: {parseDate(created)}</Typography>
+				<Typography sx={textStyle}>Created by: {agent.creator.first_name} {agent.creator.last_name}</Typography>
+			</Box>
+		</>
+	)
+}

--- a/frontend/src/components/metadata/ListenerContents.tsx
+++ b/frontend/src/components/metadata/ListenerContents.tsx
@@ -3,13 +3,6 @@ import {Box, Typography} from "@mui/material";
 import {theme} from "../../theme";
 import {parseDate} from "../../utils/common";
 
-const textStyle = {
-	fontWeight: "normal",
-	fontSize: "10px",
-	fontStyle: "italic",
-	color: theme.palette.secondary.light,
-};
-
 type ListenerContentsEntry = {
 	contents: any,
 }
@@ -18,32 +11,6 @@ type ListenerContentsEntry = {
 
 export const ListenerContents = (props: ListenerContentsEntry) => {
 	const {contents} = props;
-	// console.log(contents, 'are the contents');
-	// console.log(typeof(contents));
 
 	return <div><pre>{JSON.stringify(contents, null, 2)}</pre></div>
-
-	// return Object.entries(contents).map(([key, value], idx) => {
-	// 	// console.log('objectKey', objectKey)
-	// 	// console.log(key, 'key');
-	// 	// console.log(value, typeof(value), 'value');
-	// 	if (typeof(value) == 'object') {
-	// 		// console.log("value is an object");
-	// 		// console.log(objectKey, key, value);
-	// 		//
-	// 		console.log(idx, objectKey, key, value);
-	// 		let currentKey = key
-	// 		let entry = currentKey + ': ' + 'value goes here'
-	// 		return <li>{entry}</li>
-	//
-	//
-	// 	} else {
-	// 		if (objectKey !== undefined) {
-	// 			console.log("objectKey is not undefined", objectKey);
-	// 			console.log(value);
-	// 		}
-	// 		let entry = key + ": " +value
-	// 		return <li>{entry}</li>
-	// 	}
-	// });
 }

--- a/frontend/src/components/metadata/ListenerContents.tsx
+++ b/frontend/src/components/metadata/ListenerContents.tsx
@@ -12,13 +12,12 @@ const textStyle = {
 
 type ListenerContentsEntry = {
 	contents: any,
-	objectKey: any|undefined,
 }
 
 
 
 export const ListenerContents = (props: ListenerContentsEntry) => {
-	const {contents, objectKey} = props;
+	const {contents} = props;
 	// console.log(contents, 'are the contents');
 	// console.log(typeof(contents));
 

--- a/frontend/src/components/metadata/ListenerContents.tsx
+++ b/frontend/src/components/metadata/ListenerContents.tsx
@@ -3,6 +3,12 @@ import {Box, Typography} from "@mui/material";
 import {theme} from "../../theme";
 import {parseDate} from "../../utils/common";
 
+const textStyle = {
+	fontWeight: "normal",
+	fontSize: "16x",
+	color: theme.palette.primary,
+};
+
 type ListenerContentsEntry = {
 	contents: any,
 }

--- a/frontend/src/components/metadata/ListenerMetadataEntry.tsx
+++ b/frontend/src/components/metadata/ListenerMetadataEntry.tsx
@@ -1,11 +1,11 @@
-import React, {useEffect} from "react";
-import {Box, Grid, Typography} from "@mui/material";
+import React, {useEffect, useState} from "react";
+import {Box, Grid, Typography, Divider, Button} from "@mui/material";
 import {metadataConfig} from "../../metadata.config";
 import {useSelector, useDispatch} from "react-redux";
 import {RootState} from "../../types/data";
 import {fetchDatasetMetadata, fetchFileMetadata, fetchMetadataDefinitions} from "../../actions/metadata";
 import {ListenerAgent} from "./ListenerAgent";
-import {ListenerContents} from "./ListnerContents";
+import {ListenerContents} from "./ListenerContents";
 import {MetadataDeleteButton} from "./widgets/MetadataDeleteButton";
 
 
@@ -27,14 +27,43 @@ export const ListenerMetadataEntry = (props: ListenerMetadata) => {
 
 	const dispatch = useDispatch();
 
+	const [isOpened, setIsOpened] = useState(false);
+	const buttonTextClosed = "View Metadata";
+	const buttonTextOpened = "Hide Metadata";
+	const [buttonText, setButtonText] = useState(buttonTextClosed);
+
+	function toggle() {
+    	setIsOpened(wasOpened => !wasOpened);
+    	if (buttonText == buttonTextClosed){
+    		setButtonText(buttonTextOpened)
+		} else {
+    		setButtonText(buttonTextClosed)
+		}
+
+  	}
+
+
 	return (
 		<>
 			{
 				(() => {
 					return <Grid container spacing={2}>
 						<Grid item xs={11} sm={11} md={11} lg={11} xl={11}>
-							<ListenerAgent created={created} agent={agent} />
-							<ListenerContents contents={contents}/>
+							<div>
+								<ListenerAgent created={created} agent={agent} />
+							</div>
+							<Divider></Divider>
+								<Button
+								  onClick={toggle}
+								>
+									{buttonText}
+							</Button>
+							{isOpened && (
+								<ListenerContents
+									contents={contents}/>
+     						 )}
+
+
 						</Grid>
 					</Grid>
 

--- a/frontend/src/components/metadata/ListenerMetadataEntry.tsx
+++ b/frontend/src/components/metadata/ListenerMetadataEntry.tsx
@@ -27,10 +27,10 @@ export const ListenerMetadataEntry = (props: ListenerMetadata) => {
 
 	const dispatch = useDispatch();
 
-	const [isOpened, setIsOpened] = useState(false);
+	const [isOpened, setIsOpened] = useState(true);
 	const buttonTextClosed = "View Metadata";
 	const buttonTextOpened = "Hide Metadata";
-	const [buttonText, setButtonText] = useState(buttonTextClosed);
+	const [buttonText, setButtonText] = useState(buttonTextOpened);
 
 	function toggle() {
     	setIsOpened(wasOpened => !wasOpened);

--- a/frontend/src/components/metadata/ListenerMetadataEntry.tsx
+++ b/frontend/src/components/metadata/ListenerMetadataEntry.tsx
@@ -1,0 +1,40 @@
+import React, {useEffect} from "react";
+import {Box, Grid, Typography} from "@mui/material";
+import {metadataConfig} from "../../metadata.config";
+import {useSelector, useDispatch} from "react-redux";
+import {RootState} from "../../types/data";
+import {fetchDatasetMetadata, fetchFileMetadata, fetchMetadataDefinitions} from "../../actions/metadata";
+import {Agent} from "./Agent";
+import {MetadataDeleteButton} from "./widgets/MetadataDeleteButton";
+
+
+type ListenerMetadata = {
+	agent: any,
+	contents: any,
+	context: any,
+	context_url: any,
+	created: string,
+}
+
+/*
+This is the interface displayed already created metadata and allow eidts
+Uses only the list of metadata
+*/
+export const ListenerMetadataEntry = (props: ListenerMetadata) => {
+
+	const {agent, contents, context, context_url, created} = props;
+
+	const dispatch = useDispatch();
+
+	return (
+		<>
+			{
+				(() => {
+					console.log(contents);
+					return "Nothing yet"
+
+				})()
+			}
+		</>
+	)
+}

--- a/frontend/src/components/metadata/ListenerMetadataEntry.tsx
+++ b/frontend/src/components/metadata/ListenerMetadataEntry.tsx
@@ -4,7 +4,8 @@ import {metadataConfig} from "../../metadata.config";
 import {useSelector, useDispatch} from "react-redux";
 import {RootState} from "../../types/data";
 import {fetchDatasetMetadata, fetchFileMetadata, fetchMetadataDefinitions} from "../../actions/metadata";
-import {Agent} from "./Agent";
+import {ListenerAgent} from "./ListenerAgent";
+import {ListenerContents} from "./ListnerContents";
 import {MetadataDeleteButton} from "./widgets/MetadataDeleteButton";
 
 
@@ -30,8 +31,13 @@ export const ListenerMetadataEntry = (props: ListenerMetadata) => {
 		<>
 			{
 				(() => {
-					console.log(contents);
-					return "Nothing yet"
+					return <Grid container spacing={2}>
+						<Grid item xs={11} sm={11} md={11} lg={11} xl={11}>
+							<ListenerAgent created={created} agent={agent} />
+							<ListenerContents contents={contents}/>
+						</Grid>
+					</Grid>
+
 
 				})()
 			}

--- a/frontend/src/components/metadata/ListnerContents.tsx
+++ b/frontend/src/components/metadata/ListnerContents.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import {Box, Typography} from "@mui/material";
+import {theme} from "../../theme";
+import {parseDate} from "../../utils/common";
+
+const textStyle = {
+	fontWeight: "normal",
+	fontSize: "10px",
+	fontStyle: "italic",
+	color: theme.palette.secondary.light,
+};
+
+
+export const ListenerContents = (props) => {
+	const {contents} = props;
+	console.log(contents, 'are the contents')
+	console.log(typeof(contents));
+	return Object.entries(contents).map(([key, value]) => {
+		let entry = key + ": " +value
+		return <li>{entry}</li>
+	});
+}

--- a/frontend/src/components/metadata/ListnerContents.tsx
+++ b/frontend/src/components/metadata/ListnerContents.tsx
@@ -10,13 +10,38 @@ const textStyle = {
 	color: theme.palette.secondary.light,
 };
 
+type ListenerContentsEntry = {
+	contents: any,
+	objectKey: any|undefined,
+}
 
-export const ListenerContents = (props) => {
-	const {contents} = props;
-	console.log(contents, 'are the contents')
-	console.log(typeof(contents));
-	return Object.entries(contents).map(([key, value]) => {
-		let entry = key + ": " +value
-		return <li>{entry}</li>
+
+
+export const ListenerContents = (props: ListenerContentsEntry) => {
+	const {contents, objectKey} = props;
+	// console.log(contents, 'are the contents');
+	// console.log(typeof(contents));
+	return Object.entries(contents).map(([key, value], idx) => {
+		// console.log('objectKey', objectKey)
+		// console.log(key, 'key');
+		// console.log(value, typeof(value), 'value');
+		if (typeof(value) == 'object') {
+			// console.log("value is an object");
+			// console.log(objectKey, key, value);
+			//
+			console.log(idx, objectKey, key, value);
+			let currentKey = key
+			let entry = currentKey + ': ' + 'value goes here'
+			return <li>{entry}</li>
+
+
+		} else {
+			if (objectKey !== undefined) {
+				console.log("objectKey is not undefined", objectKey);
+				console.log(value);
+			}
+			let entry = key + ": " +value
+			return <li>{entry}</li>
+		}
 	});
 }

--- a/frontend/src/components/metadata/ListnerContents.tsx
+++ b/frontend/src/components/metadata/ListnerContents.tsx
@@ -21,27 +21,30 @@ export const ListenerContents = (props: ListenerContentsEntry) => {
 	const {contents, objectKey} = props;
 	// console.log(contents, 'are the contents');
 	// console.log(typeof(contents));
-	return Object.entries(contents).map(([key, value], idx) => {
-		// console.log('objectKey', objectKey)
-		// console.log(key, 'key');
-		// console.log(value, typeof(value), 'value');
-		if (typeof(value) == 'object') {
-			// console.log("value is an object");
-			// console.log(objectKey, key, value);
-			//
-			console.log(idx, objectKey, key, value);
-			let currentKey = key
-			let entry = currentKey + ': ' + 'value goes here'
-			return <li>{entry}</li>
 
+	return <div><pre>{JSON.stringify(contents, null, 2)}</pre></div>
 
-		} else {
-			if (objectKey !== undefined) {
-				console.log("objectKey is not undefined", objectKey);
-				console.log(value);
-			}
-			let entry = key + ": " +value
-			return <li>{entry}</li>
-		}
-	});
+	// return Object.entries(contents).map(([key, value], idx) => {
+	// 	// console.log('objectKey', objectKey)
+	// 	// console.log(key, 'key');
+	// 	// console.log(value, typeof(value), 'value');
+	// 	if (typeof(value) == 'object') {
+	// 		// console.log("value is an object");
+	// 		// console.log(objectKey, key, value);
+	// 		//
+	// 		console.log(idx, objectKey, key, value);
+	// 		let currentKey = key
+	// 		let entry = currentKey + ': ' + 'value goes here'
+	// 		return <li>{entry}</li>
+	//
+	//
+	// 	} else {
+	// 		if (objectKey !== undefined) {
+	// 			console.log("objectKey is not undefined", objectKey);
+	// 			console.log(value);
+	// 		}
+	// 		let entry = key + ": " +value
+	// 		return <li>{entry}</li>
+	// 	}
+	// });
 }


### PR DESCRIPTION
With this pull request, metadata from extractors/listeners is visible under a new tab. Right now the data can be viewed, with each entry having a toggle to  view/hide metadata. 

For metadata, the following file includes some sample extractor metadata. Some of the fields are not meaningful but were included to make the json nested.
[file_metadata.txt](https://github.com/clowder-framework/clowder2/files/10385817/file_metadata.txt)
