### PR TITLE
263 endpoint to get logs by job

### DIFF
--- a/backend/app/models/listeners.py
+++ b/backend/app/models/listeners.py
@@ -114,16 +114,16 @@ class EventListenerDatasetMessage(BaseModel):
     datasetId: str
 
 
-class ExecutionLogs(BaseModel, MongoModel):
-    id: str
+class ExecutionLogs(MongoModel, BaseModel):
+    id: PyObjectId
     _typeHint: str
-    file_id: str
-    dataset_id: Optional[str]
-    job_id: str
-    extractor_id: str
+    file_id: PyObjectId
+    dataset_id: Optional[PyObjectId]
+    job_id: PyObjectId
+    extractor_id: PyObjectId
     status: str
     start: datetime
-    user_id: str
+    user_id: PyObjectId
     file: Optional[FileOut]
     user: Optional[UserOut]
     listener: Optional[EventListenerOut]

--- a/backend/app/models/listeners.py
+++ b/backend/app/models/listeners.py
@@ -120,7 +120,7 @@ class ExecutionLogs(MongoModel, BaseModel):
     file_id: PyObjectId
     dataset_id: Optional[PyObjectId]
     job_id: PyObjectId
-    extractor_id: PyObjectId
+    extractor_id: str
     status: str
     start: datetime
     user_id: PyObjectId

--- a/backend/app/models/listeners.py
+++ b/backend/app/models/listeners.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from pydantic import Field, BaseModel
-from typing import Optional, List, Union
+from typing import Optional, List
 
 from app.config import settings
+from app.models.files import FileOut
 from app.models.pyobjectid import PyObjectId
 from app.models.mongomodel import MongoModel
 from app.models.users import UserOut
@@ -111,3 +112,17 @@ class EventListenerDatasetMessage(BaseModel):
     datasetName: str
     id: str
     datasetId: str
+
+
+class ExecutionLogs(BaseModel, MongoModel):
+    id: str
+    _typeHint: str
+    file_id: str
+    job_id: str
+    extractor_id: str
+    status: str
+    start: datetime
+    user_id: str
+    file: Optional[FileOut]
+    user: Optional[UserOut]
+    listener: Optional[EventListenerOut]

--- a/backend/app/models/listeners.py
+++ b/backend/app/models/listeners.py
@@ -118,6 +118,7 @@ class ExecutionLogs(BaseModel, MongoModel):
     id: str
     _typeHint: str
     file_id: str
+    dataset_id: Optional[str]
     job_id: str
     extractor_id: str
     status: str

--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -259,10 +259,7 @@ async def get_execution_logs_by_job(
 
 
 @router.get("/logs/{log_id}", response_model=ExecutionLogs)
-async def get_log(
-    log_id: str,
-    db: MongoClient = Depends(get_db)
-):
+async def get_log(log_id: str, db: MongoClient = Depends(get_db)):
     """
     Endpoint to get one match log given log id
 

--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -258,14 +258,22 @@ async def get_execution_logs_by_job(
     return logs
 
 
-@router.get("/{listener_id}", response_model=EventListenerOut)
-async def get_listener(listener_id: str, db: MongoClient = Depends(get_db)):
-    """Return JSON information about an Event Listener if it exists."""
+@router.get("/logs/{log_id}", response_model=ExecutionLogs)
+async def get_log(
+    log_id: str,
+    db: MongoClient = Depends(get_db)
+):
+    """
+    Endpoint to get one match log given log id
+
+    Arguments:
+       log_id -- log ID
+    """
     if (
-        listener := await db["listeners"].find_one({"_id": ObjectId(listener_id)})
+        log := await db["executions_view"].find_one({"_id": ObjectId(log_id)})
     ) is not None:
-        return EventListenerOut.from_mongo(listener)
-    raise HTTPException(status_code=404, detail=f"listener {listener_id} not found")
+        return ExecutionLogs.from_mongo(log)
+    raise HTTPException(status_code=404, detail=f"Log {log_id} not found")
 
 
 @router.get("", response_model=List[EventListenerOut])
@@ -305,6 +313,16 @@ async def get_listeners(
     ):
         listeners.append(EventListenerOut.from_mongo(doc))
     return listeners
+
+
+@router.get("/{listener_id}", response_model=EventListenerOut)
+async def get_listener(listener_id: str, db: MongoClient = Depends(get_db)):
+    """Return JSON information about an Event Listener if it exists."""
+    if (
+        listener := await db["listeners"].find_one({"_id": ObjectId(listener_id)})
+    ) is not None:
+        return EventListenerOut.from_mongo(listener)
+    raise HTTPException(status_code=404, detail=f"listener {listener_id} not found")
 
 
 @router.put("/{listener_id}", response_model=EventListenerOut)

--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -133,6 +133,69 @@ async def list_default_labels(
     return await db["listeners"].distinct("properties.defaultLabels")
 
 
+@router.get("/logs", response_model=List[ExecutionLogs])
+async def get_execution_logs(
+    db: MongoClient = Depends(get_db),
+    skip: int = 0,
+    limit: int = 2,
+):
+    """
+    Get a list of all execution logs the db.
+
+    Arguments:
+       skip -- number of initial records to skip (i.e. for pagination)
+       limit -- restrict number of records to be returned (i.e. for pagination)
+    """
+    logs = []
+    for doc in (
+        await db["executions_view"].find().skip(skip).limit(limit).to_list(length=limit)
+    ):
+        logs.append(ExecutionLogs.from_mongo(doc))
+    return logs
+
+
+@router.get("/logs/extractors/{extractor_id}", response_model=List[ExecutionLogs])
+async def get_execution_logs_by_extractor(
+    db: MongoClient = Depends(get_db),
+    skip: int = 0,
+    limit: int = 2,
+):
+    """
+    Get a list of all execution logs the db.
+
+    Arguments:
+       skip -- number of initial records to skip (i.e. for pagination)
+       limit -- restrict number of records to be returned (i.e. for pagination)
+    """
+    logs = []
+    for doc in (
+        await db["executions_view"].find().skip(skip).limit(limit).to_list(length=limit)
+    ):
+        logs.append(ExecutionLogs.from_mongo(doc))
+    return logs
+
+
+@router.get("/logs/jobs/{job_id}", response_model=List[ExecutionLogs])
+async def get_execution_logs_by_job(
+    db: MongoClient = Depends(get_db),
+    skip: int = 0,
+    limit: int = 2,
+):
+    """
+    Get a list of all execution logs the db.
+
+    Arguments:
+       skip -- number of initial records to skip (i.e. for pagination)
+       limit -- restrict number of records to be returned (i.e. for pagination)
+    """
+    logs = []
+    for doc in (
+        await db["executions_view"].find().skip(skip).limit(limit).to_list(length=limit)
+    ):
+        logs.append(ExecutionLogs.from_mongo(doc))
+    return logs
+
+
 @router.get("/{listener_id}", response_model=EventListenerOut)
 async def get_listener(listener_id: str, db: MongoClient = Depends(get_db)):
     """Return JSON information about an Event Listener if it exists."""
@@ -231,65 +294,3 @@ async def delete_listener(
     else:
         raise HTTPException(status_code=404, detail=f"listener {listener_id} not found")
 
-
-@router.get("/logs", response_model=List[ExecutionLogs])
-async def get_execution_logs(
-    db: MongoClient = Depends(get_db),
-    skip: int = 0,
-    limit: int = 2,
-):
-    """
-    Get a list of all execution logs the db.
-
-    Arguments:
-       skip -- number of initial records to skip (i.e. for pagination)
-       limit -- restrict number of records to be returned (i.e. for pagination)
-    """
-    logs = []
-    for doc in (
-        await db["executions_view"].find().skip(skip).limit(limit).to_list(length=limit)
-    ):
-        logs.append(ExecutionLogs.from_mongo(doc))
-    return logs
-
-
-@router.get("/logs/extractors/{extractor_id}", response_model=List[ExecutionLogs])
-async def get_execution_logs_by_extractor(
-    db: MongoClient = Depends(get_db),
-    skip: int = 0,
-    limit: int = 2,
-):
-    """
-    Get a list of all execution logs the db.
-
-    Arguments:
-       skip -- number of initial records to skip (i.e. for pagination)
-       limit -- restrict number of records to be returned (i.e. for pagination)
-    """
-    logs = []
-    for doc in (
-        await db["executions_view"].find().skip(skip).limit(limit).to_list(length=limit)
-    ):
-        logs.append(ExecutionLogs.from_mongo(doc))
-    return logs
-
-
-@router.get("/logs/jobs/{job_id}", response_model=List[ExecutionLogs])
-async def get_execution_logs_by_job(
-    db: MongoClient = Depends(get_db),
-    skip: int = 0,
-    limit: int = 2,
-):
-    """
-    Get a list of all execution logs the db.
-
-    Arguments:
-       skip -- number of initial records to skip (i.e. for pagination)
-       limit -- restrict number of records to be returned (i.e. for pagination)
-    """
-    logs = []
-    for doc in (
-        await db["executions_view"].find().skip(skip).limit(limit).to_list(length=limit)
-    ):
-        logs.append(ExecutionLogs.from_mongo(doc))
-    return logs

--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -184,15 +184,15 @@ async def get_execution_logs_by_extractor(
     filters = [{"extractor_id": extractor_id}]
 
     if job_id is not None:
-        filters.append({"job_id": job_id})
+        filters.append({"job_id": ObjectId(job_id)})
     if status is not None:
-        filters.append({"status": status})
+        filters.append({"status": re.compile(status, re.IGNORECASE)})
     if user_id is not None:
-        filters.append({"user_id": user_id})
+        filters.append({"user_id": ObjectId(user_id)})
     if file_id is not None:
-        filters.append({"file_id": file_id})
+        filters.append({"file_id": ObjectId(file_id)})
     if dataset_id is not None:
-        filters.append({"dataset_id": dataset_id})
+        filters.append({"dataset_id": ObjectId(dataset_id)})
     query = {"$and": filters}
 
     for doc in (
@@ -233,22 +233,22 @@ async def get_execution_logs_by_job(
     """
     logs = []
 
-    filters = []
+    filters = [{"job_id": ObjectId(job_id)}]
+
     if job_id is not None:
         filters.append({"execution_id": execution_id})
     if status is not None:
-        filters.append({"status": status})
+        filters.append({"status": re.compile(status, re.IGNORECASE)})
     if user_id is not None:
-        filters.append({"user_id": user_id})
+        filters.append({"user_id": ObjectId(user_id)})
     if file_id is not None:
-        filters.append({"file_id": file_id})
+        filters.append({"file_id": ObjectId(file_id)})
     if dataset_id is not None:
-        filters.append({"dataset_id": dataset_id})
+        filters.append({"dataset_id": ObjectId(dataset_id)})
     query = {"$and": filters}
 
     for doc in (
         await db["executions_view"]
-        .find({"job_id": ObjectId(job_id)})
         .find(query)
         .skip(skip)
         .limit(limit)

--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -251,3 +251,45 @@ async def get_execution_logs(
     ):
         logs.append(ExecutionLogs.from_mongo(doc))
     return logs
+
+
+@router.get("/logs/extractors/{extractor_id}", response_model=List[ExecutionLogs])
+async def get_execution_logs_by_extractor(
+    db: MongoClient = Depends(get_db),
+    skip: int = 0,
+    limit: int = 2,
+):
+    """
+    Get a list of all execution logs the db.
+
+    Arguments:
+       skip -- number of initial records to skip (i.e. for pagination)
+       limit -- restrict number of records to be returned (i.e. for pagination)
+    """
+    logs = []
+    for doc in (
+        await db["executions_view"].find().skip(skip).limit(limit).to_list(length=limit)
+    ):
+        logs.append(ExecutionLogs.from_mongo(doc))
+    return logs
+
+
+@router.get("/logs/jobs/{job_id}", response_model=List[ExecutionLogs])
+async def get_execution_logs_by_job(
+    db: MongoClient = Depends(get_db),
+    skip: int = 0,
+    limit: int = 2,
+):
+    """
+    Get a list of all execution logs the db.
+
+    Arguments:
+       skip -- number of initial records to skip (i.e. for pagination)
+       limit -- restrict number of records to be returned (i.e. for pagination)
+    """
+    logs = []
+    for doc in (
+        await db["executions_view"].find().skip(skip).limit(limit).to_list(length=limit)
+    ):
+        logs.append(ExecutionLogs.from_mongo(doc))
+    return logs

--- a/frontend/src/openapi/v2/index.ts
+++ b/frontend/src/openapi/v2/index.ts
@@ -16,6 +16,7 @@ export type { DatasetOut } from './models/DatasetOut';
 export type { DatasetPatch } from './models/DatasetPatch';
 export type { EventListenerIn } from './models/EventListenerIn';
 export type { EventListenerOut } from './models/EventListenerOut';
+export type { ExecutionLogs } from './models/ExecutionLogs';
 export type { ExtractorInfo } from './models/ExtractorInfo';
 export type { FeedIn } from './models/FeedIn';
 export type { FeedListener } from './models/FeedListener';

--- a/frontend/src/openapi/v2/models/ExecutionLogs.ts
+++ b/frontend/src/openapi/v2/models/ExecutionLogs.ts
@@ -1,0 +1,21 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { EventListenerOut } from './EventListenerOut';
+import type { FileOut } from './FileOut';
+import type { UserOut } from './UserOut';
+
+export type ExecutionLogs = {
+    id: string;
+    file_id: string;
+    dataset_id?: string;
+    job_id: string;
+    extractor_id: string;
+    status: string;
+    start: string;
+    user_id: string;
+    file?: FileOut;
+    user?: UserOut;
+    listener?: EventListenerOut;
+}

--- a/frontend/src/openapi/v2/models/MetadataDelete.ts
+++ b/frontend/src/openapi/v2/models/MetadataDelete.ts
@@ -3,10 +3,14 @@
 /* eslint-disable */
 
 import type { EventListenerIn } from './EventListenerIn';
+import type { ExtractorInfo } from './ExtractorInfo';
+import type { LegacyEventListenerIn } from './LegacyEventListenerIn';
 
 export type MetadataDelete = {
     id?: string;
     metadata_id?: string;
     definition?: string;
     listener?: EventListenerIn;
+    extractor?: LegacyEventListenerIn;
+    extractor_info?: ExtractorInfo;
 }

--- a/frontend/src/openapi/v2/services/ListenersService.ts
+++ b/frontend/src/openapi/v2/services/ListenersService.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 import type { EventListenerIn } from '../models/EventListenerIn';
 import type { EventListenerOut } from '../models/EventListenerOut';
+import type { ExecutionLogs } from '../models/ExecutionLogs';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { request as __request } from '../core/request';
 
@@ -126,6 +127,161 @@ export class ListenersService {
         return __request({
             method: 'GET',
             path: `/api/v2/listeners/defaultLabels`,
+        });
+    }
+
+    /**
+     * Get Execution Logs
+     * Get a list of all execution logs the db.
+     *
+     * Arguments:
+     * skip -- number of initial records to skip (i.e. for pagination)
+     * limit -- restrict number of records to be returned (i.e. for pagination)
+     * @param skip
+     * @param limit
+     * @returns ExecutionLogs Successful Response
+     * @throws ApiError
+     */
+    public static getExecutionLogsApiV2ListenersLogsGet(
+        skip?: number,
+        limit: number = 2,
+    ): CancelablePromise<Array<ExecutionLogs>> {
+        return __request({
+            method: 'GET',
+            path: `/api/v2/listeners/logs`,
+            query: {
+                'skip': skip,
+                'limit': limit,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Get Execution Logs By Extractor
+     * Get a list of all execution logs the db.
+     *
+     * Arguments:
+     * extractor_id -- extractor id
+     * job_id -- execution running job id
+     * status -- filter by status
+     * user_id -- filter by user id
+     * file_id -- filter by file id
+     * dataset_id -- filter by dataset id
+     * skip -- number of initial records to skip (i.e. for pagination)
+     * limit -- restrict number of records to be returned (i.e. for pagination)
+     * @param extractorId
+     * @param jobId
+     * @param status
+     * @param userId
+     * @param fileId
+     * @param datasetId
+     * @param skip
+     * @param limit
+     * @returns ExecutionLogs Successful Response
+     * @throws ApiError
+     */
+    public static getExecutionLogsByExtractorApiV2ListenersLogsExtractorsExtractorIdGet(
+        extractorId: string,
+        jobId?: string,
+        status?: string,
+        userId?: string,
+        fileId?: string,
+        datasetId?: string,
+        skip?: number,
+        limit: number = 2,
+    ): CancelablePromise<Array<ExecutionLogs>> {
+        return __request({
+            method: 'GET',
+            path: `/api/v2/listeners/logs/extractors/${extractorId}`,
+            query: {
+                'job_id': jobId,
+                'status': status,
+                'user_id': userId,
+                'file_id': fileId,
+                'dataset_id': datasetId,
+                'skip': skip,
+                'limit': limit,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Get Execution Logs By Job
+     * Get a list of all execution logs the db.
+     *
+     * Arguments:
+     * extractor_id -- extractor id
+     * job_id -- execution running job id
+     * status -- filter by status
+     * user_id -- filter by user id
+     * file_id -- filter by file id
+     * dataset_id -- filter by dataset id
+     * skip -- number of initial records to skip (i.e. for pagination)
+     * limit -- restrict number of records to be returned (i.e. for pagination)
+     * @param jobId
+     * @param executionId
+     * @param status
+     * @param userId
+     * @param fileId
+     * @param datasetId
+     * @param skip
+     * @param limit
+     * @returns ExecutionLogs Successful Response
+     * @throws ApiError
+     */
+    public static getExecutionLogsByJobApiV2ListenersLogsJobsJobIdGet(
+        jobId: string,
+        executionId?: string,
+        status?: string,
+        userId?: string,
+        fileId?: string,
+        datasetId?: string,
+        skip?: number,
+        limit: number = 2,
+    ): CancelablePromise<Array<ExecutionLogs>> {
+        return __request({
+            method: 'GET',
+            path: `/api/v2/listeners/logs/jobs/${jobId}`,
+            query: {
+                'execution_id': executionId,
+                'status': status,
+                'user_id': userId,
+                'file_id': fileId,
+                'dataset_id': datasetId,
+                'skip': skip,
+                'limit': limit,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Get Log
+     * Endpoint to get one match log given log id
+     *
+     * Arguments:
+     * log_id -- log ID
+     * @param logId
+     * @returns ExecutionLogs Successful Response
+     * @throws ApiError
+     */
+    public static getLogApiV2ListenersLogsLogIdGet(
+        logId: string,
+    ): CancelablePromise<ExecutionLogs> {
+        return __request({
+            method: 'GET',
+            path: `/api/v2/listeners/logs/${logId}`,
+            errors: {
+                422: `Validation Error`,
+            },
         });
     }
 


### PR DESCRIPTION
Note that where the underlying data is coming from in mongodb might be subjected to change. 
-----
What this PR does:

It creates 4 endpoints:
1. get all logs: `GET /listeners/logs`
2. get one log by precise matching by `log id`: `GET /listeners/logs/{log_id}`
3. get log id belongs to same extractors with filters: `GET /listeners/logs/extractors/{extractor_id}?job_id={job_id}&user_id={user_id}&status={status}&file_id={file_id}&dataset_id={dataset_id}`
4. get log id belongs to same job with filters: `GET /listeners/logs/jobs/{job_id}?extractor_id={extractor_id}&user_id={user_id}&status={status}&file_id={file_id}&dataset_id={dataset_id}`

Note that for filtering status I set it as a regular expression partial match ignore case. For example, "submit" , "submitted", "start" will all find a match

To test:
1. import execution (logs) collection
2. import the view

Here is the zip that has everything. You might want to massage those data a little bit to your own use case
[Archive.zip](https://github.com/clowder-framework/clowder2/files/10458478/Archive.zip)

Or you can just import this static view json to test the logic
[executions_view.json.zip](https://github.com/clowder-framework/clowder2/files/10469036/executions_view.json.zip)
