### PR TITLE
281 css style change when using rjsf

### DIFF
--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -161,7 +161,12 @@ async def get_listeners(
     """
     listeners = []
     if category and label:
-        query = {"$and": [{"properties.categories": category},{"properties.defaultLabels": label}]}
+        query = {
+            "$and": [
+                {"properties.categories": category},
+                {"properties.defaultLabels": label},
+            ]
+        }
     elif category:
         query = {"properties.categories": category}
     elif label:
@@ -170,11 +175,7 @@ async def get_listeners(
         query = {}
 
     for doc in (
-        await db["listeners"]
-        .find(query)
-        .skip(skip)
-        .limit(limit)
-        .to_list(length=limit)
+        await db["listeners"].find(query).skip(skip).limit(limit).to_list(length=limit)
     ):
         listeners.append(EventListenerOut.from_mongo(doc))
     return listeners

--- a/frontend/src/components/datasets/CreateDatasetModal.tsx
+++ b/frontend/src/components/datasets/CreateDatasetModal.tsx
@@ -7,17 +7,25 @@ import LoadingOverlay from "react-loading-overlay-ts";
 import Form from "@rjsf/material-ui";
 import datasetSchema from "../../schema/datasetSchema.json";
 import {FormProps} from "@rjsf/core";
+import {ClowderRjsfTextWidget} from "../styledComponents/ClowderRjsfTextWidget";
+import {ClowderRjsfSelectWidget} from "../styledComponents/ClowderRjsfSelectWidget";
 
 type CreateDatasetModalProps = {
 	onSave: any
 }
+
+const widgets = {
+		TextWidget: ClowderRjsfTextWidget,
+		SelectWidget: ClowderRjsfSelectWidget
+	};
 
 export const CreateDatasetModal: React.FC<CreateDatasetModalProps> = (props:CreateDatasetModalProps) => {
 	const {onSave} = props;
 
 	return (
 		<Container>
-			<Form schema={datasetSchema["schema"] as FormProps<any>["schema"]}
+			<Form widgets={widgets}
+				  schema={datasetSchema["schema"] as FormProps<any>["schema"]}
 				  uiSchema={datasetSchema["uiSchema"] as FormProps<any>["uiSchema"]} // widgets={widgets}
 				  onSubmit={({formData}) => {onSave(formData);}}>
 				<Box className="inputGroup">

--- a/frontend/src/components/listeners/SubmitExtraction.tsx
+++ b/frontend/src/components/listeners/SubmitExtraction.tsx
@@ -21,6 +21,8 @@ import {FormProps} from "@rjsf/core";
 import {submitFileExtractionAction} from "../../actions/file";
 import {submitDatasetExtractionAction} from "../../actions/dataset";
 import {Extractor} from "../../types/data";
+import {ClowderRjsfSelectWidget} from "../styledComponents/ClowderRjsfSelectWidget";
+import {ClowderRjsfTextWidget} from "../styledComponents/ClowderRjsfTextWidget";
 
 type SubmitExtractionProps = {
 	fileId: string,
@@ -28,8 +30,13 @@ type SubmitExtractionProps = {
 	open: boolean,
 	handleClose: any,
 	selectedExtractor: Extractor
-
 }
+
+const widgets = {
+		TextWidget: ClowderRjsfTextWidget,
+		SelectWidget: ClowderRjsfSelectWidget
+	};
+
 export default function SubmitExtraction(props: SubmitExtractionProps) {
 
 
@@ -90,6 +97,7 @@ export default function SubmitExtraction(props: SubmitExtractionProps) {
 									&& selectedExtractor["properties"]["parameters"]["schema"] ?
 										<Container>
 											<Form
+												widgets={widgets}
 												schema={{"properties": selectedExtractor["properties"]["parameters"]["schema"] as FormProps<any>["schema"]}}
 												onSubmit={({formData}) => {
 													onSubmit(formData);

--- a/frontend/src/components/styledComponents/ClowderInputLabel.jsx
+++ b/frontend/src/components/styledComponents/ClowderInputLabel.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import {styled} from "@mui/styles";
+import {Typography} from "@mui/material";
+import {theme} from "../../theme";
+
+export const ClowderInputLabel = styled(Typography)({
+	color: theme.palette.primary.main,
+	fontSize: "14px",
+	fontWeight: "500",
+});

--- a/frontend/src/components/styledComponents/ClowderRjsfSelectWidget.jsx
+++ b/frontend/src/components/styledComponents/ClowderRjsfSelectWidget.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import {Select, MenuItem} from "@mui/material";
+import {ClowderInputLabel} from "./ClowderInputLabel";
+
+export const ClowderRjsfSelectWidget = (item) => {
+	return (
+		<>
+			<ClowderInputLabel>{item.schema.title}</ClowderInputLabel>
+			<Select
+				labelId="label"
+				id="select"
+				variant="outlined"
+				defaultValue={item.schema.enum[0]}
+				onChange={(e) => {
+					item.onChange(e.target.value);
+				}}
+			>
+				{item.schema.enum.map((option, i) => {
+					return (
+						<MenuItem value={option} key={option}>
+							{item.schema.enumNames ? item.schema.enumNames[i] : item.schema.enum[i]}
+						</MenuItem>
+					);
+				})}
+			</Select>
+		</>
+	);
+};

--- a/frontend/src/components/styledComponents/ClowderRjsfTextWidget.jsx
+++ b/frontend/src/components/styledComponents/ClowderRjsfTextWidget.jsx
@@ -1,0 +1,19 @@
+import { Box } from "@material-ui/core";
+import React from "react";
+import {ClowderInput} from "./ClowderInput";
+import {ClowderInputLabel} from "./ClowderInputLabel";
+
+export const ClowderRjsfTextWidget = (item) => {
+	return (
+		<>
+			<ClowderInputLabel>{item.schema.title}</ClowderInputLabel>
+			<ClowderInput
+				value={item.value}
+				variant="outlined"
+				onChange={(e) => {
+					item.onChange(e.target.value);
+				}}
+			/>
+		</>
+	);
+};


### PR DESCRIPTION
Overwrite the default widget of RJSF library using more clowder like components (so far only textbox and select; but can write more for the future)

This also fix the background style bug when changing things on the extractor submission form 

![image](https://user-images.githubusercontent.com/13950475/214425797-3f37f02e-2e2b-47c9-88a7-af4afbd299be.png)
![image](https://user-images.githubusercontent.com/13950475/214425972-f48424fe-d918-4dee-af39-93dfd0c39e16.png)
![image](https://user-images.githubusercontent.com/13950475/214426027-e5fa3ea6-e559-4aa9-b4a5-65f66261a756.png)
