### PR TITLE
290 replace contents in metadata with content

### DIFF
--- a/backend/app/models/metadata.py
+++ b/backend/app/models/metadata.py
@@ -181,6 +181,7 @@ class MetadataBase(MongoModel):
     context: Optional[dict]  # https://json-ld.org/spec/latest/json-ld/#the-context
     context_url: Optional[str]  # single URL applying to contents
     definition: Optional[str]  # name of a metadata definition
+    content: dict
 
     @validator("context")
     def contexts_are_valid(cls, v):

--- a/backend/app/models/metadata.py
+++ b/backend/app/models/metadata.py
@@ -121,10 +121,10 @@ class MetadataDefinitionOut(MetadataDefinitionDB):
     pass
 
 
-def validate_definition(contents: dict, metadata_def: MetadataDefinitionOut):
+def validate_definition(content: dict, metadata_def: MetadataDefinitionOut):
     """Convenience function for checking if a value matches MetadataDefinition criteria"""
     # Reject if there are any extraneous fields
-    for entry in contents:
+    for entry in content:
         found = False
         for field in metadata_def.fields:
             if field.name == entry:
@@ -138,19 +138,19 @@ def validate_definition(contents: dict, metadata_def: MetadataDefinitionOut):
 
     # For all fields in definition, are they present and matching format?
     for field in metadata_def.fields:
-        if field.name in contents:
-            value = contents[field.name]
+        if field.name in content:
+            value = content[field.name]
             t = FIELD_TYPES[field.config.type]
             try:
                 # Try casting value as required type, raise exception if unable
-                contents[field.name] = t(contents[field.name])
+                content[field.name] = t(content[field.name])
             except ValueError:
                 if field.list and type(value) is list:
                     typecast_list = []
                     try:
                         for v in value:
                             typecast_list.append(t(v))
-                        contents[field.name] = typecast_list
+                        content[field.name] = typecast_list
                     except:
                         raise HTTPException(
                             status_code=400,
@@ -166,7 +166,7 @@ def validate_definition(contents: dict, metadata_def: MetadataDefinitionOut):
                 detail=f"{metadata_def.name} requires field {field.name}",
             )
     # Return original dict with any type castings applied
-    return contents
+    return content
 
 
 class MetadataAgent(MongoModel):
@@ -181,7 +181,6 @@ class MetadataBase(MongoModel):
     context: Optional[dict]  # https://json-ld.org/spec/latest/json-ld/#the-context
     context_url: Optional[str]  # single URL applying to contents
     definition: Optional[str]  # name of a metadata definition
-    contents: dict
 
     @validator("context")
     def contexts_are_valid(cls, v):
@@ -261,7 +260,7 @@ class MetadataOut(MetadataDB):
 
 async def validate_context(
     db: MongoClient,
-    contents: dict,
+    content: dict,
     definition: Optional[str] = None,
     context_url: Optional[str] = None,
     context: Optional[dict] = None,
@@ -269,7 +268,7 @@ async def validate_context(
     """Convenience function for making sure incoming metadata has valid definitions or resolvable context.
 
     Returns:
-        Metadata contents with incoming values typecast to match expected data type of any definitions
+        Metadata content with incoming values typecast to match expected data type of any definitions
     """
     if context is None and context_url is None and definition is None:
         raise HTTPException(
@@ -285,13 +284,13 @@ async def validate_context(
             md_def := await db["metadata.definitions"].find_one({"name": definition})
         ) is not None:
             md_def = MetadataDefinitionOut(**md_def)
-            contents = validate_definition(contents, md_def)
+            content = validate_definition(content, md_def)
         else:
             raise HTTPException(
                 status_code=400,
                 detail=f"{definition} is not valid metadata definition",
             )
-    return contents
+    return content
 
 
 def deep_update(orig: dict, new: dict):
@@ -310,20 +309,20 @@ async def patch_metadata(
     """Convenience function for updating original metadata contents with new entries."""
     try:
         # TODO: For list-type definitions, should we append to list instead?
-        updated_contents = deep_update(metadata["contents"], new_entries)
-        updated_contents = await validate_context(
+        updated_content = deep_update(metadata["content"], new_entries)
+        updated_content = await validate_context(
             db,
-            updated_contents,
+            updated_content,
             metadata.get("definition", None),
             metadata.get("context_url", None),
             metadata.get("context", None),
         )
-        metadata["contents"] = updated_contents
+        metadata["content"] = updated_content
         db["metadata"].replace_one(
             {"_id": metadata["_id"]}, MetadataDB(**metadata).to_mongo()
         )
         # Update entry to the metadata index
-        doc = {"doc": {"contents": metadata["contents"]}}
+        doc = {"doc": {"content": metadata["content"]}}
         update_record(es, "metadata", doc, metadata["_id"])
     except Exception as e:
         raise e

--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -161,7 +161,12 @@ async def get_listeners(
     """
     listeners = []
     if category and label:
-        query = {"$and": [{"properties.categories": category},{"properties.defaultLabels": label}]}
+        query = {
+            "$and": [
+                {"properties.categories": category},
+                {"properties.defaultLabels": label},
+            ]
+        }
     elif category:
         query = {"properties.categories": category}
     elif label:
@@ -170,11 +175,7 @@ async def get_listeners(
         query = {}
 
     for doc in (
-        await db["listeners"]
-        .find(query)
-        .skip(skip)
-        .limit(limit)
-        .to_list(length=limit)
+        await db["listeners"].find(query).skip(skip).limit(limit).to_list(length=limit)
     ):
         listeners.append(EventListenerOut.from_mongo(doc))
     return listeners

--- a/backend/app/routers/metadata_files.py
+++ b/backend/app/routers/metadata_files.py
@@ -44,9 +44,9 @@ async def _build_metadata_db_obj(
 ):
     """Convenience function for building a MetadataDB object from incoming metadata plus a file. Agent and file version
     will be determined based on inputs if they are not provided directly."""
-    contents = await validate_context(
+    content = await validate_context(
         db,
-        metadata_in.contents,
+        metadata_in.content,
         metadata_in.definition,
         metadata_in.context_url,
         metadata_in.context,
@@ -94,7 +94,7 @@ async def _build_metadata_db_obj(
 
     # Apply any typecast fixes from definition validation
     metadata_in = metadata_in.dict()
-    metadata_in["contents"] = contents
+    metadata_in["content"] = content
     return MetadataDB(
         **metadata_in,
         resource=file_ref,
@@ -146,7 +146,7 @@ async def add_file_metadata(
             "resource_type": "file",
             "created": metadata_out.created.utcnow(),
             "creator": user.email,
-            "contents": metadata_out.contents,
+            "content": metadata_out.content,
             "context_url": metadata_out.context_url,
             "context": metadata_out.context,
             "name": file.name,

--- a/backend/app/tests/test_datasets.py
+++ b/backend/app/tests/test_datasets.py
@@ -62,7 +62,7 @@ def test_delete_with_metadata(client: TestClient, headers: dict):
         f"{settings.API_V2_STR}/datasets/{dataset_id}/metadata",
         headers=headers,
         json={
-            "contents": {"color": "blue"},
+            "content": {"color": "blue"},
             "context_url": "clowder.org",
         },
     )

--- a/backend/app/tests/test_metadata.py
+++ b/backend/app/tests/test_metadata.py
@@ -164,9 +164,7 @@ async def test_dataset_patch_metadata_definition(client: TestClient, headers: di
     result = search_index(es, "metadata", metadata_query)
     print(result)
     assert (
-        result.body["responses"][0]["hits"]["hits"][0]["_source"]["content"][
-            "latitude"
-        ]
+        result.body["responses"][0]["hits"]["hits"][0]["_source"]["content"]["latitude"]
         == 24.4
     )
 

--- a/backend/app/tests/test_metadata.py
+++ b/backend/app/tests/test_metadata.py
@@ -57,12 +57,12 @@ metadata_definition2 = {
 }
 
 metadata_using_definition = {
-    "contents": {"latitude": "24.4", "longitude": 32.04},
+    "content": {"latitude": "24.4", "longitude": 32.04},
     "definition": "LatLon",
 }
 
 metadata_using_context_url = {
-    "contents": {"alternateName": "different name"},
+    "content": {"alternateName": "different name"},
     "context_url": "http://clowderframework.org",
 }
 
@@ -116,7 +116,7 @@ def test_dataset_create_metadata_definition(client: TestClient, headers: dict):
 
     # Add metadata that doesn't match definition
     bad_md = dict(metadata_using_definition)
-    bad_md["contents"] = {"x": "24.4", "y": 32.04}
+    bad_md["content"] = {"x": "24.4", "y": 32.04}
     response = client.post(
         f"{settings.API_V2_STR}/datasets/{dataset_id}/metadata",
         headers=headers,
@@ -160,11 +160,11 @@ async def test_dataset_patch_metadata_definition(client: TestClient, headers: di
     # header
     metadata_query.append({"index": "metadata"})
     # body
-    metadata_query.append({"query": {"match": {"contents.latitude": "24.4"}}})
+    metadata_query.append({"query": {"match": {"content.latitude": "24.4"}}})
     result = search_index(es, "metadata", metadata_query)
     print(result)
     assert (
-        result.body["responses"][0]["hits"]["hits"][0]["_source"]["contents"][
+        result.body["responses"][0]["hits"]["hits"][0]["_source"]["content"][
             "latitude"
         ]
         == 24.4
@@ -197,12 +197,12 @@ async def test_dataset_create_metadata_context_url(client: TestClient, headers: 
     metadata_query.append({"index": "metadata"})
     # body
     metadata_query.append(
-        {"query": {"match": {"contents.alternateName": "different name"}}}
+        {"query": {"match": {"content.alternateName": "different name"}}}
     )
     result = search_index(es, "metadata", metadata_query)
     print(result)
     assert (
-        result.body["responses"][0]["hits"]["hits"][0]["_source"]["contents"][
+        result.body["responses"][0]["hits"]["hits"][0]["_source"]["content"][
             "alternateName"
         ]
         == "different name"
@@ -295,7 +295,7 @@ def test_file_create_metadata_definition(client: TestClient, headers: dict):
 
     # Add metadata that doesn't match definition
     bad_md = dict(metadata_using_definition)
-    bad_md["contents"] = {"x": "24.4", "y": 32.04}
+    bad_md["content"] = {"x": "24.4", "y": 32.04}
     response = client.post(
         f"{settings.API_V2_STR}/datasets/{dataset_id}/metadata",
         headers=headers,

--- a/frontend/src/components/datasets/CreateDataset.tsx
+++ b/frontend/src/components/datasets/CreateDataset.tsx
@@ -65,8 +65,8 @@ export const CreateDataset = (): JSX.Element => {
 		setMetadataRequestForms(prevState => {
 			// merge the contents field; e.g. lat lon
 			if (metadata.definition in prevState){
-				const prevContent = prevState[metadata.definition].contents;
-				metadata.contents = {...prevContent, ...metadata.contents};
+				const prevContent = prevState[metadata.definition].content;
+				metadata.content = {...prevContent, ...metadata.content};
 			}
 			return ({...prevState, [metadata.definition]: metadata});
 		});

--- a/frontend/src/components/datasets/Dataset.tsx
+++ b/frontend/src/components/datasets/Dataset.tsx
@@ -105,10 +105,10 @@ export const Dataset = (): JSX.Element => {
 	const setMetadata = (metadata: any) => {
 		// TODO wrap this in to a function
 		setMetadataRequestForms(prevState => {
-			// merge the contents field; e.g. lat lon
+			// merge the content field; e.g. lat lon
 			if (metadata.definition in prevState) {
-				const prevContent = prevState[metadata.definition].contents;
-				metadata.contents = {...prevContent, ...metadata.contents};
+				const prevContent = prevState[metadata.definition].content;
+				metadata.content = {...prevContent, ...metadata.content};
 			}
 			return ({...prevState, [metadata.definition]: metadata});
 		});

--- a/frontend/src/components/files/File.tsx
+++ b/frontend/src/components/files/File.tsx
@@ -136,10 +136,10 @@ export const File = (): JSX.Element => {
 		console.log('metadata in file component');
 		console.log(metadata);
 		setMetadataRequestForms(prevState => {
-			// merge the contents field; e.g. lat lon
+			// merge the content field; e.g. lat lon
 			if (metadata.definition in prevState) {
-				const prevContent = prevState[metadata.definition].contents;
-				metadata.contents = {...prevContent, ...metadata.contents};
+				const prevContent = prevState[metadata.definition].content;
+				metadata.content = {...prevContent, ...metadata.content};
 			}
 			return ({...prevState, [metadata.definition]: metadata});
 		});

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -50,7 +50,6 @@ export const UploadFile:React.FC<UploadFileProps> = (props: UploadFileProps) => 
 			if (metadata.definition in prevState){
 				const prevContent = prevState[metadata.definition].content;
 				metadata.content = {...prevContent, ...metadata.content};
-				metadata.content = {...prevContent, ...metadata.content};
 			}
 			return ({...prevState, [metadata.definition]: metadata});
 		});

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -48,8 +48,9 @@ export const UploadFile:React.FC<UploadFileProps> = (props: UploadFileProps) => 
 		setMetadataRequestForms(prevState => {
 			// merge the contents field; e.g. lat lon
 			if (metadata.definition in prevState){
-				const prevContent = prevState[metadata.definition].contents;
-				metadata.contents = {...prevContent, ...metadata.contents};
+				const prevContent = prevState[metadata.definition].content;
+				metadata.content = {...prevContent, ...metadata.content};
+				metadata.content = {...prevContent, ...metadata.content};
 			}
 			return ({...prevState, [metadata.definition]: metadata});
 		});

--- a/frontend/src/components/metadata/DisplayListenerMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayListenerMetadata.tsx
@@ -63,7 +63,7 @@ export const DisplayListenerMetadata = (props: MetadataType) => {
 							return (<Grid item xs={12}><Card key={idx}>
 								<CardContent>
 									<ListenerMetadataEntry agent={metadata.agent}
-														   contents={metadata.contents}
+														   content={metadata.content}
 														   context={metadata.context}
 														   context_url={metadata.context_url}
 														   created={metadata.created}

--- a/frontend/src/components/metadata/DisplayMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayMetadata.tsx
@@ -67,11 +67,11 @@ export const DisplayMetadata = (props: MetadataType) => {
 													metadataConfig[field.widgetType ?? "NA"] ?? metadataConfig["NA"],
 													{
 														widgetName: metadataDef.name,
-														fieldName: field.name,
+														fieldName: field.,
 														options: field.config.options ?? [],
 														initialReadOnly: true,
 														resourceId: resourceId,
-														contents: metadata.contents ?? null,
+														content: metadata.content ?? null,
 														metadataId: metadata.id ?? null,
 														updateMetadata: updateMetadata,
 														key:idxx

--- a/frontend/src/components/metadata/DisplayMetadata.tsx
+++ b/frontend/src/components/metadata/DisplayMetadata.tsx
@@ -67,7 +67,7 @@ export const DisplayMetadata = (props: MetadataType) => {
 													metadataConfig[field.widgetType ?? "NA"] ?? metadataConfig["NA"],
 													{
 														widgetName: metadataDef.name,
-														fieldName: field.,
+														fieldName: field,
 														options: field.config.options ?? [],
 														initialReadOnly: true,
 														resourceId: resourceId,

--- a/frontend/src/components/metadata/EditMetadata.tsx
+++ b/frontend/src/components/metadata/EditMetadata.tsx
@@ -107,7 +107,7 @@ export const EditMetadata = (props: MetadataType) => {
 															setMetadata: setMetadata,
 															initialReadOnly: false,
 															resourceId: resourceId,
-															contents: metadata.contents ?? null,
+															content: metadata.content ?? null,
 															metadataId: metadata.id ?? null,
 															key:idxx
 														}

--- a/frontend/src/components/metadata/ListenerContents.tsx
+++ b/frontend/src/components/metadata/ListenerContents.tsx
@@ -9,14 +9,14 @@ const textStyle = {
 	color: theme.palette.primary,
 };
 
-type ListenerContentsEntry = {
-	contents: any,
+type ListenerContentEntry = {
+	content: any,
 }
 
 
 
-export const ListenerContents = (props: ListenerContentsEntry) => {
-	const {contents} = props;
+export const ListenerContents = (props: ListenerContentEntry) => {
+	const {content} = props;
 
-	return <div><pre>{JSON.stringify(contents, null, 2)}</pre></div>
+	return <div><pre>{JSON.stringify(content, null, 2)}</pre></div>
 }

--- a/frontend/src/components/metadata/ListenerMetadataEntry.tsx
+++ b/frontend/src/components/metadata/ListenerMetadataEntry.tsx
@@ -11,7 +11,7 @@ import {MetadataDeleteButton} from "./widgets/MetadataDeleteButton";
 
 type ListenerMetadata = {
 	agent: any,
-	contents: any,
+	content: any,
 	context: any,
 	context_url: any,
 	created: string,
@@ -23,7 +23,7 @@ Uses only the list of metadata
 */
 export const ListenerMetadataEntry = (props: ListenerMetadata) => {
 
-	const {agent, contents, context, context_url, created} = props;
+	const {agent, content, context, context_url, created} = props;
 
 	const dispatch = useDispatch();
 
@@ -60,7 +60,7 @@ export const ListenerMetadataEntry = (props: ListenerMetadata) => {
 							</Button>
 							{isOpened && (
 								<ListenerContents
-									contents={contents}/>
+									content={content}/>
      						 )}
 
 

--- a/frontend/src/components/metadata/widgets/MetadataDateTimePicker.tsx
+++ b/frontend/src/components/metadata/widgets/MetadataDateTimePicker.tsx
@@ -9,7 +9,7 @@ import {Grid} from "@mui/material";
 
 export const MetadataDateTimePicker = (props) => {
 	const {widgetName, fieldName, metadataId, contents, setMetadata, initialReadOnly, resourceId, updateMetadata} = props;
-	const [localContent, setLocalContent] = useState(contents && contents[fieldName] ? contents: {});
+	const [localContent, setLocalContent] = useState(content && content[fieldName] ? content: {});
 
 	const [readOnly, setReadOnly] = useState(initialReadOnly);
 
@@ -25,12 +25,12 @@ export const MetadataDateTimePicker = (props) => {
 				setMetadata({
 					"id": metadataId,
 					"definition": widgetName,
-					"contents": tempContents
+					"content": tempContents
 				})
 				:
 				setMetadata({
 					"definition": widgetName,
-					"contents": tempContents
+					"content": tempContents
 				})
 			:
 			null

--- a/frontend/src/components/metadata/widgets/MetadataDateTimePicker.tsx
+++ b/frontend/src/components/metadata/widgets/MetadataDateTimePicker.tsx
@@ -8,7 +8,7 @@ import {Grid} from "@mui/material";
 
 
 export const MetadataDateTimePicker = (props) => {
-	const {widgetName, fieldName, metadataId, contents, setMetadata, initialReadOnly, resourceId, updateMetadata} = props;
+	const {widgetName, fieldName, metadataId, content, setMetadata, initialReadOnly, resourceId, updateMetadata} = props;
 	const [localContent, setLocalContent] = useState(content && content[fieldName] ? content: {});
 
 	const [readOnly, setReadOnly] = useState(initialReadOnly);
@@ -44,7 +44,7 @@ export const MetadataDateTimePicker = (props) => {
                     <LocalizationProvider dateAdapter={AdapterDayjs}>
 						<DateTimePicker
 							label={widgetName}
-							value={readOnly && contents ? contents[fieldName]: localContent[fieldName]}
+							value={readOnly && content ? content[fieldName]: localContent[fieldName]}
 							onChange={handleChange}
 							renderInput={(params) =>
 								<ClowderMetadataTextField {...params} fullWidth

--- a/frontend/src/components/metadata/widgets/MetadataDateTimePicker.tsx
+++ b/frontend/src/components/metadata/widgets/MetadataDateTimePicker.tsx
@@ -56,7 +56,7 @@ export const MetadataDateTimePicker = (props) => {
 				</Grid>
 				<Grid item xs={1} sm={1} md={1} lg={1} xl={1}>
 					<MetadataEditButton readOnly={readOnly} setReadOnly={setReadOnly} updateMetadata={updateMetadata}
-										contents={localContent} metadataId={metadataId} resourceId={resourceId}
+										content={localContent} metadataId={metadataId} resourceId={resourceId}
 										widgetName={widgetName} setInputChanged={setInputChanged}
 										setMetadata={setMetadata}/>
 				</Grid>

--- a/frontend/src/components/metadata/widgets/MetadataEditButton.tsx
+++ b/frontend/src/components/metadata/widgets/MetadataEditButton.tsx
@@ -8,7 +8,7 @@ type MetadataEditButtonType = {
 	readOnly: boolean,
 	setReadOnly: any,
 	updateMetadata: any,
-	contents: object,
+	content: object,
 	metadataId: string|undefined,
 	resourceId: string|undefined,
 	widgetName: string,
@@ -19,7 +19,7 @@ type MetadataEditButtonType = {
 export const MetadataEditButton = (props: MetadataEditButtonType) => {
 
 	const {readOnly, setReadOnly, metadataId, updateMetadata, setMetadata,
-		resourceId, contents, widgetName, setInputChanged} = props;
+		resourceId, content, widgetName, setInputChanged} = props;
 
 	return (
 		<>
@@ -50,7 +50,7 @@ export const MetadataEditButton = (props: MetadataEditButtonType) => {
 										updateMetadata(resourceId, {
 											"id":metadataId,
 											"definition": widgetName,
-											"contents": contents
+											"content": content
 										});
 										setReadOnly(true);
 										setInputChanged(false);

--- a/frontend/src/components/metadata/widgets/MetadataSelect.tsx
+++ b/frontend/src/components/metadata/widgets/MetadataSelect.tsx
@@ -6,9 +6,9 @@ import {ClowderMetadataFormHelperText} from "../../styledComponents/ClowderMetad
 import {MetadataEditButton} from "./MetadataEditButton";
 
 export const MetadataSelect = (props) => {
-	const {widgetName, fieldName, metadataId, contents, setMetadata, initialReadOnly, options, resourceId,
+	const {widgetName, fieldName, metadataId, content, setMetadata, initialReadOnly, options, resourceId,
 		updateMetadata} = props;
-	const [localContent, setLocalContent] = useState(contents && contents[fieldName] ? contents: {});
+	const [localContent, setLocalContent] = useState(content && content[fieldName] ? content: {});
 
 	const [readOnly, setReadOnly] = useState(initialReadOnly);
 
@@ -41,7 +41,7 @@ export const MetadataSelect = (props) => {
 				<Grid item xs={11} sm={11} md={11} lg={11} xl={11}>
 					<FormControl fullWidth>
 						<InputLabel>{widgetName}</InputLabel>
-						<ClowderMetadataSelect value={readOnly && contents ? contents[fieldName]: localContent[fieldName]}
+						<ClowderMetadataSelect value={readOnly && content ? content[fieldName]: localContent[fieldName]}
 											   label="Unit" onChange={handleChange}
 											   sx={{background:"#ffffff"}}
 											   disabled={readOnly}
@@ -58,7 +58,7 @@ export const MetadataSelect = (props) => {
 				</Grid>
 				<Grid item xs={1} sm={1} md={1} lg={1} xl={1}>
 					<MetadataEditButton readOnly={readOnly} setReadOnly={setReadOnly} updateMetadata={updateMetadata}
-										contents={localContent} metadataId={metadataId} resourceId={resourceId}
+										content={localContent} metadataId={metadataId} resourceId={resourceId}
 										widgetName={widgetName} setInputChanged={setInputChanged}
 										setMetadata={setMetadata}/>
 				</Grid>

--- a/frontend/src/components/metadata/widgets/MetadataSelect.tsx
+++ b/frontend/src/components/metadata/widgets/MetadataSelect.tsx
@@ -23,12 +23,12 @@ export const MetadataSelect = (props) => {
 				setMetadata({
 					"id":metadataId,
 					"definition": widgetName,
-					"contents": tempContents
+					"content": tempContents
 				})
 				:
 				setMetadata({
 					"definition": widgetName,
-					"contents": tempContents
+					"content": tempContents
 				})
 			:
 			null

--- a/frontend/src/components/metadata/widgets/MetadataTextField.tsx
+++ b/frontend/src/components/metadata/widgets/MetadataTextField.tsx
@@ -26,12 +26,12 @@ export const MetadataTextField = (props) => {
 													  setMetadata({
 														  "id":metadataId,
 														  "definition": widgetName,
-														  "contents": tempContents
+														  "content": tempContents
 													  })
 													  :
 													  setMetadata({
 														  "definition": widgetName,
-														  "contents": tempContents
+														  "content": tempContents
 													  })
 												  :
 												  null
@@ -42,7 +42,7 @@ export const MetadataTextField = (props) => {
 			</Grid>
 			<Grid item xs={1} sm={1} md={1} lg={1} xl={1}>
 				<MetadataEditButton readOnly={readOnly} setReadOnly={setReadOnly} updateMetadata={updateMetadata}
-									contents={localContent} metadataId={metadataId} resourceId={resourceId}
+									content={localContent} metadataId={metadataId} resourceId={resourceId}
 									widgetName={widgetName} setInputChanged={setInputChanged}
 									setMetadata={setMetadata}
 				/>

--- a/frontend/src/openapi/v2/models/MetadataIn.ts
+++ b/frontend/src/openapi/v2/models/MetadataIn.ts
@@ -11,7 +11,7 @@ export type MetadataIn = {
     context?: any;
     context_url?: string;
     definition?: string;
-    contents: any;
+    content: any;
     file_version?: number;
     listener?: EventListenerIn;
     extractor?: LegacyEventListenerIn;

--- a/frontend/src/openapi/v2/models/MetadataOut.ts
+++ b/frontend/src/openapi/v2/models/MetadataOut.ts
@@ -10,7 +10,7 @@ export type MetadataOut = {
     context?: any;
     context_url?: string;
     definition?: string;
-    contents: any;
+    content: any;
     resource: MongoDBRef;
     agent: MetadataAgent;
     created?: string;

--- a/frontend/src/openapi/v2/models/MetadataPatch.ts
+++ b/frontend/src/openapi/v2/models/MetadataPatch.ts
@@ -11,7 +11,7 @@ export type MetadataPatch = {
     context?: any;
     context_url?: string;
     definition?: string;
-    contents: any;
+    content: any;
     file_version?: number;
     listener?: EventListenerIn;
     extractor?: LegacyEventListenerIn;


### PR DESCRIPTION
Testing some extractors I realized the field that was 'content' in v1 was changed to 'contents' in v2, which caused a number of extractors not to work with clowder v2. 

With this pull request I have changed 'contents' to 'content' everywhere, in the back end and front end, hoping that this will reduce the amount of changes that might need to be made to older extractors or in pyclowder. 

Currently wordcount extractors works correctly. 

Other extractor related issues will be taken care of in other pull requests. 