### PR TITLE
adding restart unless stopped for this container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -151,6 +151,7 @@ services:
       - RABBITMQ_PASS=${RABBITMQ_PASS:-guest}
     networks:
       - clowder2
+    restart: unless-stopped
     depends_on:
       - mongo
       - rabbitmq


### PR DESCRIPTION
Sometimes the container for the heartbeat listener would stop and need to be restarted. This should fix the problem. 