### PR TITLE
changing context to list in metadata defs

### DIFF
--- a/scripts/metadata/definitions/alternativeTitle.json
+++ b/scripts/metadata/definitions/alternativeTitle.json
@@ -1,9 +1,11 @@
 {
     "name" : "AlternativeTitle",
     "description" : "Alternative title",
-    "context" : {
+    "context" : [
+        {
         "title" : "https://schema.org/alternateName"
-    },
+        }
+    ],
     "fields" : [
         {
             "name" : "alternateName",

--- a/scripts/metadata/definitions/coordinates.json
+++ b/scripts/metadata/definitions/coordinates.json
@@ -1,9 +1,11 @@
 {
     "name" : "Coordinates",
     "description" : "Any number of Latitude/Longitude coordinates",
-    "context" : {
-        "point": "https://schema.org/point"
-    },
+    "context" : [
+        {
+            "point": "https://schema.org/point"
+        }
+    ],
     "fields" : [
         {
             "name" : "point",

--- a/scripts/metadata/definitions/doi.json
+++ b/scripts/metadata/definitions/doi.json
@@ -1,9 +1,11 @@
 {
     "name" : "DOI",
     "description" : "Digital object identifier",
-    "context" : {
-        "doi" : "https://schema.org/DigitalDocument"
-    },
+    "context" : [
+        {
+            "doi" : "https://schema.org/DigitalDocument"
+        }
+    ],
     "fields" : [
         {
             "name" : "doi",

--- a/scripts/metadata/definitions/latLon.json
+++ b/scripts/metadata/definitions/latLon.json
@@ -1,10 +1,12 @@
 {
     "name" : "LatLon",
     "description" : "A set of Latitude/Longitude coordinates",
-    "context" : {
-        "longitude" : "https://schema.org/longitude",
-        "latitude" : "https://schema.org/latitude"
-    },
+    "context" : [
+        {
+            "longitude" : "https://schema.org/longitude",
+            "latitude" : "https://schema.org/latitude"
+        }
+    ],
     "fields" : [
         {
             "name" : "longitude",

--- a/scripts/metadata/definitions/time.json
+++ b/scripts/metadata/definitions/time.json
@@ -1,9 +1,11 @@
 {
     "name" : "Time",
     "description" : "time",
-    "context" : {
-        "doi" : "https://schema.org/Time"
-    },
+    "context" : [
+        {
+            "doi" : "https://schema.org/Time"
+        },
+    ],
     "fields" : [
         {
             "name" : "time",

--- a/scripts/metadata/definitions/unit.json
+++ b/scripts/metadata/definitions/unit.json
@@ -1,9 +1,11 @@
 {
     "name" : "Unit",
     "description" : "Unit",
-    "context" : {
-        "doi" : "https://schema.org/QuantitativeValue"
-    },
+    "context" : [
+        {
+            "doi" : "https://schema.org/QuantitativeValue"
+        }
+    ],
     "fields" : [
         {
             "name" : "unit",


### PR DESCRIPTION
When working on the metadata UI issues I noticed these aren't updated to fit context being a list. Thought it should be its own pull request rather than adding it to that one. 