### PR TITLE
fix the search

### DIFF
--- a/frontend/src/components/listeners/Listeners.tsx
+++ b/frontend/src/components/listeners/Listeners.tsx
@@ -71,6 +71,12 @@ export function Listeners(props: ListenerProps) {
 		else setNextDisabled(false);
 	}, [listeners]);
 
+	// search
+	useEffect(() => {
+		if (searchText !== "") handleListenerSearch();
+		else listListeners(skip, limit, selectedCategory, selectedLabel);
+	}, [searchText]);
+
 	useEffect(() => {
 		if (skip !== null && skip !== undefined) {
 			listListeners(skip, limit, null, null);
@@ -142,8 +148,8 @@ export function Listeners(props: ListenerProps) {
 							onKeyDown={(e) => {
 								if (e.key === "Enter") {
 									e.preventDefault();
+									handleListenerSearch();
 								}
-								handleListenerSearch();
 							}}
 							value={searchText}
 						/>


### PR DESCRIPTION
Now searching when typing; when hit enter or the "search" icon, it will also search the current word. When erase or empty string, list default listeners. 

To test you can watch the network tab:
<img width="518" alt="image" src="https://user-images.githubusercontent.com/13950475/230477394-9995cc2d-aced-41d3-bfd6-5c3d98577af1.png">
