### PR TITLE
implement expires parameter for user keys

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     # Unique secret for hashing API keys. Generate with `openssl rand -hex 32`
     local_auth_secret = "clowder_secret_key"
-    local_auth_expiration = 30  # number of minutes before invalidating API key
+    local_auth_expiration = 30  # default number of minutes before invalidating API key (can be individually overridden)
 
     # exposing default ports for fronted
     CORS_ORIGINS: List[AnyHttpUrl] = [

--- a/backend/app/keycloak_auth.py
+++ b/backend/app/keycloak_auth.py
@@ -96,9 +96,8 @@ async def get_token(
             ) is not None:
                 key = UserAPIKey.from_mongo(key_entry)
                 current_time = datetime.utcnow()
-                mins_since = int((current_time - key.created).total_seconds() / 60)
 
-                if mins_since > settings.local_auth_expiration:
+                if key.expires is not None and current_time >= key.expires:
                     # Expired key, delete it first
                     db["user_keys"].delete_one({"_id": ObjectId(key.id)})
                     raise HTTPException(
@@ -166,9 +165,8 @@ async def get_current_user(
             ) is not None:
                 key = UserAPIKey.from_mongo(key_entry)
                 current_time = datetime.utcnow()
-                mins_since = int((current_time - key.created).total_seconds() / 60)
 
-                if mins_since > settings.local_auth_expiration:
+                if key.expires is not None and current_time >= key.expires:
                     # Expired key, delete it first
                     db["user_keys"].delete_one({"_id": ObjectId(key.id)})
                     raise HTTPException(
@@ -229,9 +227,8 @@ async def get_current_username(
             ) is not None:
                 key = UserAPIKey.from_mongo(key_entry)
                 current_time = datetime.utcnow()
-                mins_since = int((current_time - key.created).total_seconds() / 60)
 
-                if mins_since > settings.local_auth_expiration:
+                if key.expires is not None and current_time >= key.expires:
                     # Expired key, delete it first
                     db["user_keys"].delete_one({"_id": ObjectId(key.id)})
                     raise HTTPException(

--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -45,6 +45,7 @@ class UserAPIKey(MongoModel):
     key: str
     user: EmailStr
     created: datetime = Field(default_factory=datetime.utcnow)
+    expires: Optional[datetime] = None
 
 
 class UserAndRole(BaseModel):

--- a/frontend/src/openapi/v2/services/UsersService.ts
+++ b/frontend/src/openapi/v2/services/UsersService.ts
@@ -69,13 +69,26 @@ export class UsersService {
 
     /**
      * Generate User Api Key
+     * Generate an API key that confers the user's privileges.
+     *
+     * Arguments:
+     * mins -- number of minutes before expiration (0 for no expiration)
+     * @param mins
      * @returns string Successful Response
      * @throws ApiError
      */
-    public static generateUserApiKeyApiV2UsersKeysPost(): CancelablePromise<string> {
+    public static generateUserApiKeyApiV2UsersKeysPost(
+        mins: number = 30,
+    ): CancelablePromise<string> {
         return __request({
             method: 'POST',
             path: `/api/v2/users/keys`,
+            query: {
+                'mins': mins,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
         });
     }
 


### PR DESCRIPTION
Allow dynamic expiration of individual API keys.

To generate a key, POST to /users/keys?mins=2 for a 2-minute expiration, default is 30.