### PR TITLE
Autocomplete on sharing pop-ups

### DIFF
--- a/frontend/src/components/datasets/ShareDatasetModal.tsx
+++ b/frontend/src/components/datasets/ShareDatasetModal.tsx
@@ -1,33 +1,66 @@
 import React, { useEffect, useState } from "react";
-import { Alert, Autocomplete, Button, Collapse, Container, Dialog, DialogActions, DialogContent, DialogTitle, Divider, FormControl, IconButton, InputLabel, MenuItem, Select, TextField, Typography } from "@mui/material";
-import {useParams} from "react-router-dom";
+import {
+	Alert,
+	Autocomplete,
+	Button,
+	Collapse,
+	Container,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Divider,
+	FormControl,
+	IconButton,
+	InputLabel,
+	MenuItem,
+	Select,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { useParams } from "react-router-dom";
 import { setDatasetUserRole } from "../../actions/dataset";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import CloseIcon from "@mui/icons-material/Close";
-
+import { fetchAllUsers } from "../../actions/user";
+import { UserOut } from "../../openapi/v2";
+import { RootState } from "../../types/data";
 
 type ShareDatasetModalProps = {
-    open: boolean,
-    handleClose: any,
-    datasetName: string
-}
+	open: boolean;
+	handleClose: any;
+	datasetName: string;
+};
 
 export default function ShareDatasetModal(props: ShareDatasetModalProps) {
 	const dispatch = useDispatch();
 
+	const listAllUsers = (skip: number, limit: number) =>
+		dispatch(fetchAllUsers(skip, limit));
+
 	const { open, handleClose, datasetName } = props;
-	const {datasetId} = useParams<{ datasetId?: string }>();
+	const { datasetId } = useParams<{ datasetId?: string }>();
 	const [email, setEmail] = useState("");
 	const [role, setRole] = useState("viewer");
 	const [showSuccessAlert, setShowSuccessAlert] = useState(false);
+	const [options, setOptions] = useState([]);
+	const users = useSelector((state: RootState) => state.group.users);
 
-	const setUserRole = (datasetId: string, username: string, role: string) => dispatch(setDatasetUserRole(datasetId, username, role));
+	const setUserRole = (datasetId: string, username: string, role: string) =>
+		dispatch(setDatasetUserRole(datasetId, username, role));
 
-	// component did mount
 	useEffect(() => {
-		// listUsers();
+		listAllUsers(0, 21);
 	}, []);
-    
+
+	useEffect(() => {
+		setOptions(
+			users.reduce((list: string[], user: UserOut) => {
+				return [...list, user.email];
+			}, [])
+		);
+	}, [users]);
+
 	const onShare = () => {
 		setUserRole(datasetId, email, role);
 		setEmail("");
@@ -37,20 +70,27 @@ export default function ShareDatasetModal(props: ShareDatasetModalProps) {
 
 	return (
 		<Container>
-			<Dialog open={open} onClose={handleClose} fullWidth={true} maxWidth="md"
+			<Dialog
+				open={open}
+				onClose={handleClose}
+				fullWidth={true}
+				maxWidth="md"
 				sx={{
 					".MuiPaper-root": {
 						padding: "2em",
 					},
-				}}>
+				}}
+			>
 				<DialogTitle>Share dataset &apos;{datasetName}&apos;</DialogTitle>
 				<Divider />
 				<DialogContent>
 					<Typography>Invite people to collaborate</Typography>
-					<div style={{
-						display: "flex",
-						alignItems: "center"
-					}}>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+						}}
+					>
 						<Autocomplete
 							id="email-auto-complete"
 							freeSolo
@@ -59,9 +99,22 @@ export default function ShareDatasetModal(props: ShareDatasetModalProps) {
 							onInputChange={(event, value) => {
 								setEmail(value);
 							}}
-							options={["abc@xyz.com"]}
-							renderInput={(params) => <TextField {...params} sx={{ mt: 1, mr: 1, "alignItems": "right", "width": "450px" }} required label="Enter email address" />}
-						/> as
+							options={options}
+							renderInput={(params) => (
+								<TextField
+									{...params}
+									sx={{
+										mt: 1,
+										mr: 1,
+										alignItems: "right",
+										width: "450px",
+									}}
+									required
+									label="Enter email address"
+								/>
+							)}
+						/>{" "}
+						as
 						<FormControl variant="outlined" sx={{ m: 1, minWidth: 120 }}>
 							<InputLabel id="demo-simple-select-label">Status</InputLabel>
 							<Select
@@ -81,9 +134,16 @@ export default function ShareDatasetModal(props: ShareDatasetModalProps) {
 							</Select>
 						</FormControl>
 					</div>
-					<Button variant="contained" sx={{ marginTop: 1 }} onClick={onShare} disabled={(email.length > 0) ? false : true}>Share</Button>
+					<Button
+						variant="contained"
+						sx={{ marginTop: 1 }}
+						onClick={onShare}
+						disabled={email.length > 0 ? false : true}
+					>
+						Share
+					</Button>
 					<Collapse in={showSuccessAlert}>
-						<br/>
+						<br />
 						<Alert
 							severity="success"
 							action={
@@ -100,7 +160,7 @@ export default function ShareDatasetModal(props: ShareDatasetModalProps) {
 							}
 							sx={{ mb: 2 }}
 						>
-                        Successfully added role!
+							Successfully added role!
 						</Alert>
 					</Collapse>
 				</DialogContent>

--- a/frontend/src/components/datasets/ShareGroupDatasetModal.tsx
+++ b/frontend/src/components/datasets/ShareGroupDatasetModal.tsx
@@ -1,95 +1,120 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 
-import {useDispatch, useSelector} from "react-redux";
-import { Alert, Autocomplete, Button, Collapse, Container, Dialog, DialogActions, DialogContent, DialogTitle, Divider, FormControl, IconButton, InputLabel, MenuItem, Select, TextField, Typography } from "@mui/material";
-import {fetchGroups} from "../../actions/group";
-import {RootState} from "../../types/data";
-import {setDatasetGroupRole} from "../../actions/dataset";
-import {useParams} from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import {
+	Alert,
+	Autocomplete,
+	Button,
+	Collapse,
+	Container,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Divider,
+	FormControl,
+	IconButton,
+	InputLabel,
+	MenuItem,
+	Select,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { fetchGroups } from "../../actions/group";
+import { RootState } from "../../types/data";
+import { setDatasetGroupRole } from "../../actions/dataset";
+import { useParams } from "react-router-dom";
 import CloseIcon from "@mui/icons-material/Close";
+import { GroupOut } from "../../openapi/v2";
 
 type ShareGroupDatasetModalProps = {
-    open: boolean,
-    handleClose: any,
-    datasetName: string
-}
+	open: boolean;
+	handleClose: any;
+	datasetName: string;
+};
 
-export default function ShareGroupDatasetModal(props: ShareGroupDatasetModalProps) {
-   	const { open, handleClose, datasetName } = props;
-	const {datasetId} = useParams<{ datasetId?: string }>();
-    	const [role, setRole] = useState("viewer");
+export default function ShareGroupDatasetModal(
+	props: ShareGroupDatasetModalProps
+) {
+	const { open, handleClose, datasetName } = props;
+	const { datasetId } = useParams<{ datasetId?: string }>();
+	const [role, setRole] = useState("viewer");
 	const [group, setGroup] = useState("");
-    	const [showSuccessAlert, setShowSuccessAlert] = useState(false);
+	const [options, setOptions] = useState([]);
+	const [showSuccessAlert, setShowSuccessAlert] = useState(false);
 	const dispatch = useDispatch();
 	const listGroups = () => dispatch(fetchGroups(0, 21));
 	const groups = useSelector((state: RootState) => state.group.groups);
-	const setGroupRole = (datasetId: string , groupId: string, role: string) => dispatch(setDatasetGroupRole(datasetId, groupId, role));
-
+	const setGroupRole = (datasetId: string, groupId: string, role: string) =>
+		dispatch(setDatasetGroupRole(datasetId, groupId, role));
 
 	// component did mount
 	useEffect(() => {
 		listGroups();
 	}, []);
 
+	useEffect(() => {
+		setOptions(
+			groups.reduce((list: string[], group: GroupOut) => {
+				return [...list, group.name];
+			}, [])
+		);
+	}, [groups]);
+
 	const onShare = () => {
-    	console.log(group, datasetId,role);
-    	setGroupRole(datasetId, group, role);
+		setGroupRole(datasetId, group, role);
 		setGroup("");
 		setRole("viewer");
 		setShowSuccessAlert(true);
 	};
 
-
-
-	const options = Array();
-    	groups.map((group) => {
-    	const group_option = {value:group.id, label:group.name};
-		options.push(group_option);
-    	});
-	console.log("group optioins are", options);
-	console.log("it is of type", typeof(options));
-
 	return (
 		<Container>
-			<Dialog open={open} onClose={handleClose} fullWidth={true} maxWidth="md"
+			<Dialog
+				open={open}
+				onClose={handleClose}
+				fullWidth={true}
+				maxWidth="md"
 				sx={{
 					".MuiPaper-root": {
 						padding: "2em",
 					},
-				}}>
+				}}
+			>
 				<DialogTitle>Share dataset &apos;{datasetName}&apos;</DialogTitle>
 				<Divider />
 				<DialogContent>
 					<Typography>Invite groups to collaborate</Typography>
-					<div style={{
-						display: "flex",
-						alignItems: "center"
-					}}>
-						<FormControl variant="outlined" sx={{ m: 1, minWidth: 120 }}>
-							<InputLabel id="demo-simple-select-label">Group</InputLabel>
-							<Select
-                                	labelId="demo-simple-select-label"
-                                	id="demo-simple-select"
-								value={group}
-								// defaultValue={"641214ebfe6405bc949730c6"}
-								label="Group"
-                                	onChange={(event, value) => {
-                                		console.log(event, value);
-                                		console.log("chose a new group");
-                                		console.log(event.target.value);
-                                    		setGroup(event.target.value);
-                                	}}
-                            	>
-								{options.map((group) => (
-            					<MenuItem
-										key={group.label}
-										value={group.value}
-									>
-										{group.label}
-            					</MenuItem>
-								))}
-                            	</Select>
-						</FormControl>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+						}}
+					>
+						<Autocomplete
+							id="email-auto-complete"
+							freeSolo
+							autoHighlight
+							inputValue={group}
+							onInputChange={(event, value) => {
+								setGroup(value);
+							}}
+							options={options}
+							renderInput={(params) => (
+								<TextField
+									{...params}
+									sx={{
+										mt: 1,
+										mr: 1,
+										alignItems: "right",
+										width: "450px",
+									}}
+									required
+									label="Enter group name"
+								/>
+							)}
+						/>{" "}
+						as
 						<FormControl variant="outlined" sx={{ m: 1, minWidth: 120 }}>
 							<InputLabel id="demo-simple-select-label">Status</InputLabel>
 							<Select
@@ -99,7 +124,6 @@ export default function ShareGroupDatasetModal(props: ShareGroupDatasetModalProp
 								defaultValue={"viewer"}
 								label="Status"
 								onChange={(event, value) => {
-                                	console.log(event, value);
 									setRole(event.target.value);
 								}}
 							>
@@ -110,9 +134,16 @@ export default function ShareGroupDatasetModal(props: ShareGroupDatasetModalProp
 							</Select>
 						</FormControl>
 					</div>
-					<Button variant="contained" sx={{ marginTop: 1 }} onClick={onShare} disabled={(group.length > 0) ? false : true}>Share</Button>
+					<Button
+						variant="contained"
+						sx={{ marginTop: 1 }}
+						onClick={onShare}
+						disabled={group.length > 0 ? false : true}
+					>
+						Share
+					</Button>
 					<Collapse in={showSuccessAlert}>
-						<br/>
+						<br />
 						<Alert
 							severity="success"
 							action={
@@ -129,7 +160,7 @@ export default function ShareGroupDatasetModal(props: ShareGroupDatasetModalProp
 							}
 							sx={{ mb: 2 }}
 						>
-                        Successfully added role!
+							Successfully added role!
 						</Alert>
 					</Collapse>
 				</DialogContent>

--- a/frontend/src/components/groups/AddMemberModal.tsx
+++ b/frontend/src/components/groups/AddMemberModal.tsx
@@ -1,82 +1,99 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import {
 	Autocomplete,
-	Box,
 	Button,
 	Container,
 	Dialog,
 	DialogActions,
 	DialogContent,
 	DialogTitle,
-	FormControl,
-	InputLabel,
-	MenuItem,
-	Select,
-	TextField
+	TextField,
 } from "@mui/material";
-import {addGroupMember} from "../../actions/group";
-import {useDispatch, useSelector} from "react-redux";
-import {fetchAllUsers} from "../../actions/user";
-import {RootState} from "../../types/data";
-import {UserOut} from "../../openapi/v2";
+import { addGroupMember } from "../../actions/group";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchAllUsers } from "../../actions/user";
+import { RootState } from "../../types/data";
+import { UserOut } from "../../openapi/v2";
 import GroupsIcon from "@mui/icons-material/Groups";
 
-
 type AddMemberModalProps = {
-    open: boolean,
-    handleClose: any,
-    groupName: string,
-	groupId: string|undefined,
-}
+	open: boolean;
+	handleClose: any;
+	groupName: string;
+	groupId: string | undefined;
+};
 
 export default function AddMemberModal(props: AddMemberModalProps) {
-    const { open, handleClose, groupName, groupId } = props;
+	const { open, handleClose, groupName, groupId } = props;
 
-    const dispatch = useDispatch();
-    const listAllUsers = (skip:number, limit:number) => dispatch(fetchAllUsers(skip, limit));
-    const groupMemberAdded = (groupId:string | undefined, username: string | undefined) => dispatch(addGroupMember(groupId, username));
-    const users = useSelector((state: RootState) => state.group.users);
+	const dispatch = useDispatch();
+	const listAllUsers = (skip: number, limit: number) =>
+		dispatch(fetchAllUsers(skip, limit));
+	const groupMemberAdded = (
+		groupId: string | undefined,
+		username: string | undefined
+	) => dispatch(addGroupMember(groupId, username));
+	const users = useSelector((state: RootState) => state.group.users);
 
-    const [email, setEmail] = useState("");
-    const [options, setOptions] = useState([]);
+	const [email, setEmail] = useState("");
+	const [options, setOptions] = useState([]);
 
 	useEffect(() => {
 		listAllUsers(0, 21);
-	}, [])
+	}, []);
 
-	useEffect(() =>{
-		setOptions(users.reduce((list:string[], user:UserOut) => { return [...list, user.email];}, []));
-	}, [users])
+	useEffect(() => {
+		setOptions(
+			users.reduce((list: string[], user: UserOut) => {
+				return [...list, user.email];
+			}, [])
+		);
+	}, [users]);
 
-	const handleAddButtonClick = () =>{
+	const handleAddButtonClick = () => {
 		groupMemberAdded(groupId, email);
 		setEmail("");
 		handleClose();
-	}
-    return (
-        <Container>
-            <Dialog open={open} onClose={handleClose} fullWidth={true}>
-                <DialogTitle>Add People to <GroupsIcon sx={{verticalAlign: "middle", fontSize: "1.5em",
-					margin: "auto 5px"}}/>{groupName}</DialogTitle>
-                <DialogContent>
+	};
+	return (
+		<Container>
+			<Dialog open={open} onClose={handleClose} fullWidth={true}>
+				<DialogTitle>
+					Add People to{" "}
+					<GroupsIcon
+						sx={{
+							verticalAlign: "middle",
+							fontSize: "1.5em",
+							margin: "auto 5px",
+						}}
+					/>
+					{groupName}
+				</DialogTitle>
+				<DialogContent>
 					<Autocomplete
 						id="email-auto-complete"
 						freeSolo
 						autoHighlight
 						inputValue={email}
 						onInputChange={(_, value) => {
-							setEmail(value)
+							setEmail(value);
 						}}
 						options={options}
-						renderInput={(params) =>
-							<TextField {...params} sx={{mt: 1, width: "100%" }} required label="Enter email address" />}
+						renderInput={(params) => (
+							<TextField
+								{...params}
+								sx={{ mt: 1, width: "100%" }}
+								required
+								label="Enter email address"
+							/>
+						)}
 					/>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={handleAddButtonClick}>Add</Button>
-                    <Button onClick={handleClose}>Cancel</Button>
-                </DialogActions>
-            </Dialog>
-        </Container>
-    );
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={handleAddButtonClick}>Add</Button>
+					<Button onClick={handleClose}>Cancel</Button>
+				</DialogActions>
+			</Dialog>
+		</Container>
+	);
 }


### PR DESCRIPTION
This implements Autocomplete form with dynamic state for both user and group sharing forms on dataset page. Groups were already there, but switched to Autocomplete as code was cleaner and we should use that pattern where possible.