### PR TITLE
format in local timezone

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
 				"babel-polyfill": "^6.26.0",
 				"classnames": "^2.2.6",
 				"date-fns": "^2.28.0",
+				"date-fns-tz": "^2.0.0",
 				"html-react-parser": "^3.0.4",
 				"jquery": "^3.6.0",
 				"jwt-decode": "^3.0.0",
@@ -8017,6 +8018,14 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/date-fns"
+			}
+		},
+		"node_modules/date-fns-tz": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+			"integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+			"peerDependencies": {
+				"date-fns": ">=2.0.0"
 			}
 		},
 		"node_modules/dayjs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
 		"babel-polyfill": "^6.26.0",
 		"classnames": "^2.2.6",
 		"date-fns": "^2.28.0",
+		"date-fns-tz": "^2.0.0",
 		"html-react-parser": "^3.0.4",
 		"jquery": "^3.6.0",
 		"jwt-decode": "^3.0.0",

--- a/frontend/src/utils/common.js
+++ b/frontend/src/utils/common.js
@@ -1,7 +1,7 @@
 import Cookies from "universal-cookie";
 import { V2 } from "../openapi";
-import { format } from "date-fns";
 import jwt_decode from "jwt-decode";
+import { formatInTimeZone } from "date-fns-tz";
 
 const cookies = new Cookies();
 
@@ -68,7 +68,13 @@ export function dataURItoFile(dataURI) {
 export function parseDate(dateString) {
 	if (dateString) {
 		try {
-			return format(new Date(dateString), "yyyy-MM-dd HH:mm:ss");
+			const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+			// need to add Zulu (Z) to the end if it's not present
+			if (!dateString.endsWith("Z")) dateString = `${dateString}Z`;
+			const date = new Date(dateString);
+
+			return formatInTimeZone(date, timeZone, "yyyy-MM-dd HH:mm:ss");
 		} catch (error) {
 			console.error(error);
 			return error["message"];


### PR DESCRIPTION
Because backend datetime.utcnow() doesn't come with a trailing Z (Zulu), the frontend cannot treat the time as utc. 
The fix would be on the frontend add Z and parse with timezone info.

This explains why python datetime.utcnow() doesn't have the Z https://stackoverflow.com/a/63731605