### PR TITLE
Metadata & search bugfixes

### DIFF
--- a/backend/app/keycloak_auth.py
+++ b/backend/app/keycloak_auth.py
@@ -213,7 +213,7 @@ async def get_current_username(
             payload = serializer.loads(api_key)
             # Key is valid, check expiration date in database
             key = await UserAPIKeyDB.find_one(
-                UserAPIKeyDB.user == payload["user"], UserAPIKeyDB.key == payload.key
+                UserAPIKeyDB.user == payload["user"], UserAPIKeyDB.key == payload["key"]
             )
             if key is not None:
                 current_time = datetime.utcnow()

--- a/backend/app/rabbitmq/listeners.py
+++ b/backend/app/rabbitmq/listeners.py
@@ -106,7 +106,7 @@ async def submit_dataset_job(
         resource_ref=MongoDBRef(collection="dataset", resource_id=dataset_out.id),
         parameters=parameters,
     )
-    await job.save()
+    await job.insert()
 
     msg_body = EventListenerDatasetJobMessage(
         datasetName=dataset_out.name,

--- a/backend/app/routers/authorization.py
+++ b/backend/app/routers/authorization.py
@@ -57,7 +57,7 @@ async def save_authorization(
             status_code=404, detail=f"Groups not found: {missing_groups}"
         )
 
-    authorization = await AuthorizationDB(
+    authorization = AuthorizationDB(
         **authorization_in.dict(), creator=user, user_ids=user_ids
     )
     await authorization.insert()

--- a/backend/app/routers/datasets.py
+++ b/backend/app/routers/datasets.py
@@ -188,7 +188,7 @@ async def save_dataset(
     es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
 ):
     dataset = DatasetDB(**dataset_in.dict(), creator=user)
-    await dataset.save()
+    await dataset.insert()
 
     # Create authorization entry
     await AuthorizationDB(

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -7,7 +7,7 @@ from typing import Union
 from beanie import PydanticObjectId
 from beanie.odm.operators.update.general import Inc
 from bson import ObjectId
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, NotFoundError
 from fastapi import APIRouter, HTTPException, Depends, Security
 from fastapi import (
     File,
@@ -35,6 +35,7 @@ from app.rabbitmq.listeners import submit_file_job, EventListenerJobDB
 from app.routers.feeds import check_feed_listeners
 from app.search.connect import (
     delete_document_by_id,
+    insert_record,
     update_record,
     delete_document_by_query,
 )
@@ -254,7 +255,10 @@ async def update_file(
                     "bytes": updated_file.bytes,
                 }
             }
-            update_record(es, "metadata", doc, str(metadata.id))
+            try:
+                update_record(es, "metadata", {"doc": doc}, str(metadata.id))
+            except NotFoundError:
+                insert_record(es, "metadata", doc, str(metadata.id))
         return updated_file.dict()
     else:
         raise HTTPException(status_code=404, detail=f"File {file_id} not found")

--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -89,7 +89,7 @@ async def get_instance_id(
             for _ in range(10)
         )
         config_entry = ConfigEntryDB(key="instance_id", value=instance_id)
-        await config_entry.save()
+        await config_entry.insert()
         return config_entry
 
 
@@ -101,8 +101,8 @@ async def save_listener(
     """Register a new Event Listener with the system."""
     listener = EventListenerDB(**listener_in.dict(), creator=user)
     # TODO: Check for duplicates somehow?
-    await listener.save()
     return listener.dict()
+    await listener.insert()
 
 
 @legacy_router.post("", response_model=EventListenerOut)

--- a/backend/app/routers/listeners.py
+++ b/backend/app/routers/listeners.py
@@ -101,8 +101,8 @@ async def save_listener(
     """Register a new Event Listener with the system."""
     listener = EventListenerDB(**listener_in.dict(), creator=user)
     # TODO: Check for duplicates somehow?
-    return listener.dict()
     await listener.insert()
+    return listener.dict()
 
 
 @legacy_router.post("", response_model=EventListenerOut)

--- a/backend/app/routers/metadata.py
+++ b/backend/app/routers/metadata.py
@@ -39,7 +39,7 @@ async def save_metadata_definition(
         )
     else:
         md_def = MetadataDefinitionDB(**definition_in.dict(), creator=user)
-        await md_def.save()
+        await md_def.insert()
         return md_def.dict()
 
 

--- a/backend/app/routers/metadata_datasets.py
+++ b/backend/app/routers/metadata_datasets.py
@@ -327,7 +327,7 @@ async def delete_dataset_metadata(
             query.append(MetadataDB.agent.creator.id == agent.creator.id)
 
         # delete from elasticsearch
-        delete_document_by_id(es, "metadata", str(metadata_in.id))
+        delete_document_by_id(es, "metadata", str(metadata_in.metadata_id))
 
         md = await MetadataDB.find_one(*query)
         if md is not None:

--- a/backend/app/routers/metadata_files.py
+++ b/backend/app/routers/metadata_files.py
@@ -28,7 +28,7 @@ from app.models.metadata import (
     MetadataDelete,
     MetadataDefinitionDB,
 )
-from app.search.connect import insert_record, update_record, delete_document_by_id
+from app.search.connect import delete_document_by_id
 from app.search.index import index_file_metadata
 
 router = APIRouter()
@@ -139,7 +139,7 @@ async def add_file_metadata(
                 )
             else:
                 existing_q.append(MetadataDB.agent.creator.id == user.id)
-            if (existing := await MetadataDB().find_one(existing_q)) is not None:
+            if (existing := await MetadataDB.find_one(*existing_q)) is not None:
                 # Allow creating duplicate entry only if the file version is different
                 if existing.resource.version == metadata_in.file_version:
                     raise HTTPException(
@@ -207,7 +207,7 @@ async def replace_file_metadata(
             agent = MetadataAgent(creator=user)
             query.append(MetadataDB.agent.creator.id == agent.creator.id)
 
-        if (md := await MetadataDB(*query).find_one()) is not None:
+        if (orig_md := await MetadataDB.find_one(*query)) is not None:
             # Metadata exists, so prepare the new document we are going to replace it with
             md = await _build_metadata_db_obj(
                 metadata_in,
@@ -216,6 +216,7 @@ async def replace_file_metadata(
                 agent=agent,
                 version=target_version,
             )
+            md.id = orig_md.id
             await md.save()
 
             # Update entry to the metadata index
@@ -246,10 +247,10 @@ async def update_file_metadata(
 
     # check if metadata with file version exists, replace metadata if none exists
     if (
-        await MetadataDB(
+        await MetadataDB.find_one(
             MetadataDB.resource.resource_id == ObjectId(file_id),
             MetadataDB.resource.version == metadata_in.file_version,
-        ).find_one()
+        )
     ) is None:
         result = await replace_file_metadata(metadata_in, file_id, user, es)
         return result
@@ -261,9 +262,9 @@ async def update_file_metadata(
         if metadata_in.metadata_id is not None:
             # If a specific metadata_id is provided, validate the patch against existing context
             if (
-                existing_md := await MetadataDB(
+                existing_md := await MetadataDB.find_one(
                     MetadataDB.id == ObjectId(metadata_in.metadata_id)
-                ).find_one()
+                )
             ) is not None:
                 content = await validate_context(
                     metadata_in.content,
@@ -372,10 +373,10 @@ async def get_file_metadata(
             query.append(MetadataDB.agent.extractor.version == extractor_version)
 
         metadata = []
-        async for md in MetadataDB.find(query):
+        async for md in MetadataDB.find(*query):
             if md.definition is not None:
                 if (
-                    md_def := await MetadataDefinitionDB(
+                    md_def := await MetadataDefinitionDB.find_one(
                         MetadataDefinitionDB.name == md.definition
                     )
                 ) is not None:
@@ -420,9 +421,9 @@ async def delete_file_metadata(
         if metadata_in.metadata_id is not None:
             # If a specific metadata_id is provided, delete the matching entry
             if (
-                await MetadataDB(
+                await MetadataDB.find_one(
                     MetadataDB.metadata_id == ObjectId(metadata_in.metadata_id)
-                ).find_one()
+                )
             ) is not None:
                 query.append(MetadataDB.metadata_id == metadata_in.metadata_id)
         else:
@@ -454,9 +455,9 @@ async def delete_file_metadata(
             query.append(MetadataDB.agent.creator.id == agent.creator.id)
 
         # delete from elasticsearch
-        delete_document_by_id(es, "metadata", str(metadata_in.id))
+        delete_document_by_id(es, "metadata", str(metadata_in.metadata_id))
 
-        if (md := await MetadataDB(*query).find_one()) is not None:
+        if (md := await MetadataDB.find_one(*query)) is not None:
             await md.delete()
             return md.dict()  # TODO: Do we need to return the object we just deleted?
         else:

--- a/backend/app/search/connect.py
+++ b/backend/app/search/connect.py
@@ -91,8 +91,6 @@ def search_index(es_client, index_name, query):
     """
     try:
         res = es_client.msearch(index=index_name, searches=query)
-        # TODO when there is error this structure response-hits-total-value does not exist
-        # logger.info("Got %d Hits:" % res.body["responses"][0]["hits"]["total"]["value"])
         return res
     except BadRequestError as ex:
         logger.error(str(ex))

--- a/backend/app/search/index.py
+++ b/backend/app/search/index.py
@@ -1,8 +1,9 @@
 from typing import Optional, List
+
 from bson import ObjectId
 from elasticsearch import Elasticsearch, NotFoundError
 
-from app.models.authorization import AuthorizationOut, AuthorizationDB
+from app.models.authorization import AuthorizationDB
 from app.models.datasets import DatasetOut
 from app.models.files import FileOut
 from app.models.metadata import MetadataOut
@@ -39,7 +40,10 @@ async def index_dataset(
         user_ids=authorized_user_ids,
     ).dict()
     if update:
-        update_record(es, "dataset", {"doc": doc}, dataset.id)
+        try:
+            update_record(es, "dataset", {"doc": doc}, dataset.id)
+        except NotFoundError:
+            insert_record(es, "dataset", doc, dataset.id)
     else:
         insert_record(es, "dataset", doc, dataset.id)
 
@@ -77,7 +81,10 @@ async def index_file(
         user_ids=authorized_user_ids,
     ).dict()
     if update:
-        update_record(es, "file", {"doc": doc}, file.id)
+        try:
+            update_record(es, "file", {"doc": doc}, file.id)
+        except NotFoundError:
+            insert_record(es, "file", doc, file.id)
     else:
         insert_record(es, "file", doc, file.id)
 
@@ -119,7 +126,10 @@ async def index_dataset_metadata(
         user_ids=authorized_user_ids,
     ).dict()
     if update:
-        update_record(es, "metadata", {"doc": doc}, metadata.id)
+        try:
+            update_record(es, "metadata", {"doc": doc}, metadata.id)
+        except NotFoundError:
+            insert_record(es, "metadata", doc, metadata.id)
     else:
         insert_record(es, "metadata", doc, metadata.id)
 

--- a/backend/message_listener.py
+++ b/backend/message_listener.py
@@ -129,7 +129,7 @@ async def callback(message: AbstractIncomingMessage):
             event_msg = EventListenerJobUpdateDB(
                 job_id=job_id, status=cleaned_msg, timestamp=timestamp
             )
-            event_msg.save()
+            event_msg.insert()
             return True
         else:
             # We don't know what this job is. Reject the message.

--- a/frontend/src/components/datasets/ChangeGroupDatasetRoleModal.tsx
+++ b/frontend/src/components/datasets/ChangeGroupDatasetRoleModal.tsx
@@ -1,57 +1,89 @@
-import React, {useEffect, useState} from "react";
+import React, { useState } from "react";
 
-import {useDispatch, useSelector} from "react-redux";
-import { Alert, Autocomplete, Button, Collapse, Container, Dialog, DialogActions, DialogContent, DialogTitle, Divider, FormControl, IconButton, InputLabel, MenuItem, Select, TextField, Typography } from "@mui/material";
-import {fetchGroups} from "../../actions/group";
-import {RootState} from "../../types/data";
-import {setDatasetGroupRole} from "../../actions/dataset";
-import {useParams} from "react-router-dom";
+import { useDispatch } from "react-redux";
+import {
+	Alert,
+	Button,
+	Collapse,
+	Container,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Divider,
+	FormControl,
+	IconButton,
+	InputLabel,
+	MenuItem,
+	Select,
+	Typography,
+} from "@mui/material";
+import { setDatasetGroupRole } from "../../actions/dataset";
+import { useParams } from "react-router-dom";
 import CloseIcon from "@mui/icons-material/Close";
 
 type ChangeGroupDatasetRoleModalProps = {
-    open: boolean,
-    handleClose: any,
-    datasetName: string,
-	currentRole: string,
-	currentGroupName: string
-	currentGroupId: string
-}
+	open: boolean;
+	handleClose: any;
+	datasetName: string;
+	currentRole: string;
+	currentGroupName: string;
+	currentGroupId: string;
+};
 
-export default function ChangeGroupDatasetRoleModal(props: ChangeGroupDatasetRoleModalProps) {
-   	const { open, handleClose, datasetName, currentRole, currentGroupName, currentGroupId } = props;
-	const {datasetId} = useParams<{ datasetId?: string }>();
+export default function ChangeGroupDatasetRoleModal(
+	props: ChangeGroupDatasetRoleModalProps
+) {
+	const {
+		open,
+		handleClose,
+		datasetName,
+		currentRole,
+		currentGroupName,
+		currentGroupId,
+	} = props;
+	const { datasetId } = useParams<{ datasetId?: string }>();
 	const [role, setRole] = useState(currentRole);
 	const [group, setGroup] = useState();
 	const [showSuccessAlert, setShowSuccessAlert] = useState(false);
 	const dispatch = useDispatch();
-	const setGroupRole = (datasetId: string , groupId: string, role: string) => dispatch(setDatasetGroupRole(datasetId, groupId, role));
-
-
+	const setGroupRole = (datasetId: string, groupId: string, role: string) =>
+		dispatch(setDatasetGroupRole(datasetId, groupId, role));
 
 	const onShare = () => {
-    	setGroupRole(datasetId, currentGroupId, role);
+		setGroupRole(datasetId, currentGroupId, role);
 		setGroup(group);
 		setRole("viewer");
 		setShowSuccessAlert(true);
 	};
 
-
 	return (
 		<Container>
-			<Dialog open={open} onClose={handleClose} fullWidth={true} maxWidth="md"
+			<Dialog
+				open={open}
+				onClose={handleClose}
+				fullWidth={true}
+				maxWidth="md"
 				sx={{
 					".MuiPaper-root": {
 						padding: "2em",
 					},
-				}}>
-				<DialogTitle>Change dataset role for &apos;{datasetName}&apos;</DialogTitle>
+				}}
+			>
+				<DialogTitle>
+					Change dataset role for &apos;{datasetName}&apos;
+				</DialogTitle>
 				<Divider />
 				<DialogContent>
 					<Typography>Invite groups to collaborate</Typography>
-					<div style={{
-						display: "flex",
-						alignItems: "center"
-					}}> group is {currentGroupName}
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+						}}
+					>
+						{" "}
+						group is {currentGroupName}
 						<FormControl variant="outlined" sx={{ m: 1, minWidth: 120 }}>
 							<InputLabel id="demo-simple-select-label">Status</InputLabel>
 							<Select
@@ -61,7 +93,6 @@ export default function ChangeGroupDatasetRoleModal(props: ChangeGroupDatasetRol
 								defaultValue={"viewer"}
 								label="Status"
 								onChange={(event, value) => {
-                                	console.log(event, value);
 									setRole(event.target.value);
 								}}
 							>
@@ -72,9 +103,11 @@ export default function ChangeGroupDatasetRoleModal(props: ChangeGroupDatasetRol
 							</Select>
 						</FormControl>
 					</div>
-					<Button variant="contained" sx={{ marginTop: 1 }} onClick={onShare}>Share</Button>
+					<Button variant="contained" sx={{ marginTop: 1 }} onClick={onShare}>
+						Share
+					</Button>
 					<Collapse in={showSuccessAlert}>
-						<br/>
+						<br />
 						<Alert
 							severity="success"
 							action={
@@ -91,7 +124,7 @@ export default function ChangeGroupDatasetRoleModal(props: ChangeGroupDatasetRol
 							}
 							sx={{ mb: 2 }}
 						>
-                        Successfully added role!
+							Successfully added role!
 						</Alert>
 					</Collapse>
 				</DialogContent>

--- a/frontend/src/components/files/File.tsx
+++ b/frontend/src/components/files/File.tsx
@@ -105,10 +105,8 @@ export const File = (): JSX.Element => {
 	useEffect(() => {
 		if (reason == "Forbidden") {
 			setShowForbiddenPage(true);
-        
 		} else if (reason == "Not Found") {
 			setShowNotFoundPage(true);
-        
 		} else if (reason !== "" && reason !== null && reason !== undefined) {
 			setErrorOpen(true);
 		}
@@ -120,7 +118,9 @@ export const File = (): JSX.Element => {
 	};
 	const handleErrorReport = () => {
 		window.open(
-			`${config.GHIssueBaseURL}+${encodeURIComponent(reason)}&body=${encodeURIComponent(stack)}`
+			`${config.GHIssueBaseURL}+${encodeURIComponent(
+				reason
+			)}&body=${encodeURIComponent(stack)}`
 		);
 	};
 
@@ -171,8 +171,6 @@ export const File = (): JSX.Element => {
 
 	const setMetadata = (metadata: any) => {
 		// TODO wrap this in to a function
-		console.log("metadata in file component");
-		console.log(metadata);
 		setMetadataRequestForms((prevState) => {
 			// merge the content field; e.g. lat lon
 			if (metadata.definition in prevState) {
@@ -211,9 +209,6 @@ export const File = (): JSX.Element => {
 
 	// const submitToListener = ()=> {
 	// 	const filename = fileSummary['name']
-	// 	console.log('submit to listener');
-	// 	console.log("the file name is", filename);
-	// 	console.log('the file id is', fileId);
 	// 	history(`/listeners?fileId=${fileId}&fileName=${filename}`);
 	// }
 
@@ -240,7 +235,6 @@ export const File = (): JSX.Element => {
 
 	if (showForbiddenPage) {
 		return <Forbidden />;
-    
 	} else if (showNotFoundPage) {
 		return <PageNotFound />;
 	}

--- a/frontend/src/components/search/Search.tsx
+++ b/frontend/src/components/search/Search.tsx
@@ -12,7 +12,6 @@ import Layout from "../Layout";
 import { SearchResult } from "./SearchResult";
 import { theme } from "../../theme";
 import { getCurrEmail } from "../../utils/common";
-import { SearchErrorBoundary } from "./SearchErrorBoundary";
 
 export function Search() {
 	const email = getCurrEmail();
@@ -48,169 +47,167 @@ export function Search() {
 								</Typography>
 							}
 						/>
-						<SearchErrorBoundary>
-							{luceneOn ? (
-								// string search
-								<DataSearch
-									title="String Search for Datasets and Files"
-									placeholder="Please use Lucene Syntax string query.
+						{luceneOn ? (
+							// string search
+							<DataSearch
+								title="String Search for Datasets and Files"
+								placeholder="Please use Lucene Syntax string query.
 									E.g.name:water~2 AND download:[0 TO 40} AND creator:myersrobert@scott-gutierrez.com"
-									componentId="string-searchbox"
-									autosuggest={false}
-									highlight={false}
+								componentId="string-searchbox"
+								autosuggest={false}
+								highlight={false}
+								queryFormat="or"
+								fuzziness={0}
+								debounce={100}
+								showFilter={false}
+								showClear
+								renderNoSuggestion="No suggestions found."
+								innerClass={{
+									title: "search-title",
+									input: "search-input",
+								}}
+								queryString={true}
+							/>
+						) : (
+							// facet search
+							<>
+								{/*search*/}
+								<DataSearch
+									title="Search for Datasets and Files"
+									placeholder="Type in any keyword that you wish to search..."
+									componentId="searchbox"
+									autosuggest={true}
+									highlight={true}
 									queryFormat="or"
 									fuzziness={0}
 									debounce={100}
-									showFilter={false}
-									showClear
-									renderNoSuggestion="No suggestions found."
-									innerClass={{
-										title: "search-title",
-										input: "search-input",
-									}}
-									queryString={true}
-								/>
-							) : (
-								// facet search
-								<>
-									{/*search*/}
-									<DataSearch
-										title="Search for Datasets and Files"
-										placeholder="Type in any keyword that you wish to search..."
-										componentId="searchbox"
-										autosuggest={true}
-										highlight={true}
-										queryFormat="or"
-										fuzziness={0}
-										debounce={100}
-										react={{
-											and: [
-												"creatorfilter",
-												"downloadfilter",
-												"modifyfilter",
-												"authFilter",
-											],
-										}}
-										// apply react to the filter
-										URLParams={true}
-										showFilter={true}
-										showClear={false}
-										renderNoSuggestion="No suggestions found."
-										dataField={["name", "description", "creator.keyword"]}
-										fieldWeights={[3, 2, 1]}
-										innerClass={{
-											title: "search-title",
-											input: "search-input",
-										}}
-									/>
-
-									{/*authorization clause - searcher must be creator or have permission to view result*/}
-									<ReactiveComponent
-										componentId="authFilter"
-										customQuery={() => ({
-											query: {
-												bool: {
-													should: [
-														// TODO: Include if dataset is public
-														{
-															term: {
-																creator: email,
-															},
-														},
-														{
-															term: {
-																user_ids: email,
-															},
-														},
-													],
-												},
-											},
-										})}
-									/>
-
-									{/*filters*/}
-									<Grid container spacing={2} sx={{ marginBottom: "20px" }}>
-										<Grid item xs={12} sm={4} md={4} lg={4}>
-											<MultiDropdownList
-												componentId="creatorfilter"
-												dataField="creator"
-												size={5}
-												sortBy="count"
-												showCount={true}
-												placeholder="Creator: All"
-												innerClass={{
-													select: "filter-select",
-												}}
-											/>
-										</Grid>
-										<Grid item xs={12} sm={4} md={4} lg={4}>
-											<SingleDropdownRange
-												componentId="downloadfilter"
-												dataField="downloads"
-												data={[
-													{ start: 0, label: "Download Times: All" },
-													{ start: 10, label: "10 time and up" },
-													{ start: 100, label: "100 times and up" },
-													{ start: 1000, label: "1000 times and up" },
-												]}
-												innerClass={{
-													select: "filter-select",
-												}}
-												defaultValue={"Download Times: All"}
-											/>
-										</Grid>
-										<Grid item xs={12} sm={4} md={4} lg={4}>
-											<DateRange
-												componentId="modifyfilter"
-												dataField="created"
-												focused={false}
-												autoFocusEnd={true}
-												numberOfMonths={1}
-												queryFormat="date_time_no_millis"
-												showClear={true}
-												showFilter={true}
-												filterLabel="Date"
-												URLParams={false}
-												placeholder={{
-													start: "From Date",
-													end: "To Date",
-												}}
-											/>
-										</Grid>
-									</Grid>
-								</>
-							)}
-							{/*result*/}
-							{luceneOn ? (
-								<ReactiveList
-									componentId="results"
-									dataField="_score"
-									size={20}
-									pagination={true}
-									react={{
-										and: ["string-searchbox"],
-									}}
-									render={({ data }) => <SearchResult data={data} />}
-								/>
-							) : (
-								<ReactiveList
-									componentId="results"
-									dataField="_score"
-									size={20}
-									pagination={true}
 									react={{
 										and: [
-											"searchbox",
 											"creatorfilter",
 											"downloadfilter",
 											"modifyfilter",
 											"authFilter",
 										],
 									}}
-									render={({ data }) => <SearchResult data={data} />}
+									// apply react to the filter
+									URLParams={true}
+									showFilter={true}
+									showClear={false}
+									renderNoSuggestion="No suggestions found."
+									dataField={["name", "description", "creator.keyword"]}
+									fieldWeights={[3, 2, 1]}
+									innerClass={{
+										title: "search-title",
+										input: "search-input",
+									}}
 								/>
-							)}
-						</SearchErrorBoundary>
+
+								{/*authorization clause - searcher must be creator or have permission to view result*/}
+								<ReactiveComponent
+									componentId="authFilter"
+									customQuery={() => ({
+										query: {
+											bool: {
+												should: [
+													// TODO: Include if dataset is public
+													{
+														term: {
+															creator: email,
+														},
+													},
+													{
+														term: {
+															user_ids: email,
+														},
+													},
+												],
+											},
+										},
+									})}
+								/>
+
+								{/*filters*/}
+								<Grid container spacing={2} sx={{ marginBottom: "20px" }}>
+									<Grid item xs={12} sm={4} md={4} lg={4}>
+										<MultiDropdownList
+											componentId="creatorfilter"
+											dataField="creator"
+											size={5}
+											sortBy="count"
+											showCount={true}
+											placeholder="Creator: All"
+											innerClass={{
+												select: "filter-select",
+											}}
+										/>
+									</Grid>
+									<Grid item xs={12} sm={4} md={4} lg={4}>
+										<SingleDropdownRange
+											componentId="downloadfilter"
+											dataField="downloads"
+											data={[
+												{ start: 0, label: "Download Times: All" },
+												{ start: 10, label: "10 time and up" },
+												{ start: 100, label: "100 times and up" },
+												{ start: 1000, label: "1000 times and up" },
+											]}
+											innerClass={{
+												select: "filter-select",
+											}}
+											defaultValue={"Download Times: All"}
+										/>
+									</Grid>
+									<Grid item xs={12} sm={4} md={4} lg={4}>
+										<DateRange
+											componentId="modifyfilter"
+											dataField="created"
+											focused={false}
+											autoFocusEnd={true}
+											numberOfMonths={1}
+											queryFormat="date_time_no_millis"
+											showClear={true}
+											showFilter={true}
+											filterLabel="Date"
+											URLParams={false}
+											placeholder={{
+												start: "From Date",
+												end: "To Date",
+											}}
+										/>
+									</Grid>
+								</Grid>
+							</>
+						)}
+						{/*result*/}
+						{luceneOn ? (
+							<ReactiveList
+								componentId="results"
+								dataField="_score"
+								size={20}
+								pagination={true}
+								react={{
+									and: ["string-searchbox"],
+								}}
+								render={({ data }) => <SearchResult data={data} />}
+							/>
+						) : (
+							<ReactiveList
+								componentId="results"
+								dataField="_score"
+								size={20}
+								pagination={true}
+								react={{
+									and: [
+										"searchbox",
+										"creatorfilter",
+										"downloadfilter",
+										"modifyfilter",
+										"authFilter",
+									],
+								}}
+								render={({ data }) => <SearchResult data={data} />}
+							/>
+						)}
 					</Grid>
 				</Grid>
 			</div>

--- a/frontend/src/components/search/SearchResult.tsx
+++ b/frontend/src/components/search/SearchResult.tsx
@@ -74,8 +74,8 @@ export function SearchResult(props) {
 							</MuiLink>
 						)}
 						<Typography variant="body2" color={theme.palette.secondary.light}>
-							`Created by ${parseString(item.creator)} at $
-							{parseDate(item.created)}`
+							Created by {parseString(item.creator)} at{" "}
+							{parseDate(item.created)}
 						</Typography>
 						<Typography variant="body2" color={theme.palette.secondary.dark}>
 							{getRecordType(item) === "dataset"

--- a/frontend/src/components/users/Profile.tsx
+++ b/frontend/src/components/users/Profile.tsx
@@ -1,62 +1,55 @@
-import React, { useEffect, useState } from "react";
-import { Box, Button, Grid, Stack, Tab, Tabs, Typography } from "@mui/material";
-import { useParams, useSearchParams } from "react-router-dom";
+import React, { useEffect } from "react";
 import { RootState } from "../../types/data";
 import { useDispatch, useSelector } from "react-redux";
 import Layout from "../Layout";
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
-import {fetchUserProfile} from "../../actions/user";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import { fetchUserProfile } from "../../actions/user";
 
 export const Profile = (): JSX.Element => {
 	const dispatch = useDispatch();
 	const user = useSelector((state: RootState) => state.user);
 	const profile = user["profile"];
 	const fetchProfile = () => dispatch(fetchUserProfile());
-	console.log('user is');
-	console.log(user);
 	// component did mount
 	useEffect(() => {
 		fetchProfile();
-		console.log(user.profile);
 	}, []);
 
-	console.log('profile is', profile);
-	if(profile != null) {
+	if (profile != null) {
 		return (
 			<Layout>
 				<TableContainer component={Paper}>
-					<Table sx={{minWidth: 650}} aria-label="simple table">
+					<Table sx={{ minWidth: 650 }} aria-label="simple table">
 						<TableHead>
 							<TableRow>
 								<TableCell>Name</TableCell>
 								<TableCell align="right">Email</TableCell>
 								<TableCell align="right">Admin</TableCell>
-								<TableCell align="right"></TableCell>
+								<TableCell align="right" />
 							</TableRow>
 						</TableHead>
-							<TableBody>
-								<TableRow
-									sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
-		>
-									<TableCell>{profile.first_name} {profile.last_name}</TableCell>
-									<TableCell align="right">{profile.email}</TableCell>
-									<TableCell align="right">{"false"}</TableCell>
-								</TableRow>
-							</TableBody>
+						<TableBody>
+							<TableRow
+								sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+							>
+								<TableCell>
+									{profile.first_name} {profile.last_name}
+								</TableCell>
+								<TableCell align="right">{profile.email}</TableCell>
+								<TableCell align="right">{"false"}</TableCell>
+							</TableRow>
+						</TableBody>
 					</Table>
 				</TableContainer>
 			</Layout>
-		)
+		);
 	} else {
-		return (
-			<p>nothing yet</p>
-		)
+		return <p>nothing yet</p>;
 	}
-
-}
+};


### PR DESCRIPTION
Fixes several bugs related to metadata:
- MetadataDB was not being queried properly in some cases (syntax)
- elasticsearch index not being built properly for all fields in the metadata
- ID of metadata was not being preserved in index on metadata updates

removed some unnecessary console logs.

Also disabled SearchErrorBoundary on search page again. we think that the new "refresh token every 60 seconds in background" will make the SearchErrorBoundary piece that catches/redirects login unnecessary. This also means the user wont see any "failed to parse syntax" messages in the UI, only "No results found." The alternative is that the lucene search box permanently breaks when user types "field:" and the colon is the final character.