### PR TITLE
Set the docker project name to ``-p clowder2-dev` when running the dev

### DIFF
--- a/.run/Docker Dev.run.xml
+++ b/.run/Docker Dev.run.xml
@@ -2,6 +2,7 @@
   <configuration default="false" name="Docker Dev" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
+        <option name="composeProjectName" value="clowder2-dev" />
         <option name="envFilePath" value="" />
         <option name="sourceFilePath" value="docker-compose.dev.yml" />
       </settings>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ section below).
   provide the container name. For example, for viewing the backend module logs, run `docker-compose logs -f backend`.
 - Running `./docker-dev.sh down` brings down the required services.
 
+**Note:** `./docker-dev.sh` sets the project name flag to `-p clowder2-dev`. This is so that the dev containers
+don't get mixed with the production containers if the user is running both on the same machine using `docker-compose.yml`.
+If this is not used, the keycloak container will use the volume created with the other docker compose and it will be
+unable to run as the information stored in the postgres database is different.
+
 ### Backend Module
 
 After starting up the required services, setup and run the backend module.

--- a/docker-dev.sh
+++ b/docker-dev.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 if [ $1 == "up" ]
 then
-  docker-compose -f docker-compose.dev.yml up -d
+  docker-compose -f docker-compose.dev.yml -p clowder2-dev up -d
 fi
 if [ $1 == "down" ]
 then
-  docker-compose -f docker-compose.dev.yml down
+  docker-compose -f docker-compose.dev.yml -p clowder2-dev down
 fi


### PR DESCRIPTION
stack so that keycloak doesn't fail if both dev and prod are ran on the same host. #457 