### PR TITLE
enable visualization for dataset

### DIFF
--- a/frontend/src/components/datasets/Dataset.tsx
+++ b/frontend/src/components/datasets/Dataset.tsx
@@ -39,6 +39,8 @@ import { TabStyle } from "../../styles/Styles";
 import { Forbidden } from "../errors/Forbidden";
 import { PageNotFound } from "../errors/PageNotFound";
 import { ErrorModal } from "../errors/ErrorModal";
+import { Visualization } from "../visualizations/Visualization";
+import VisibilityIcon from "@mui/icons-material/Visibility";
 
 export const Dataset = (): JSX.Element => {
 	// path parameter
@@ -230,11 +232,19 @@ export const Dataset = (): JSX.Element => {
 							{...a11yProps(0)}
 						/>
 						<Tab
+							icon={<VisibilityIcon />}
+							iconPosition="start"
+							sx={TabStyle}
+							label="Visualizations"
+							{...a11yProps(1)}
+							disabled={false}
+						/>
+						<Tab
 							icon={<FormatListBulleted />}
 							iconPosition="start"
 							sx={TabStyle}
 							label="User Metadata"
-							{...a11yProps(1)}
+							{...a11yProps(2)}
 							disabled={false}
 						/>
 						<Tab
@@ -242,7 +252,7 @@ export const Dataset = (): JSX.Element => {
 							iconPosition="start"
 							sx={TabStyle}
 							label="Extracted Metadata"
-							{...a11yProps(2)}
+							{...a11yProps(3)}
 							disabled={false}
 						/>
 						<Tab
@@ -250,7 +260,7 @@ export const Dataset = (): JSX.Element => {
 							iconPosition="start"
 							sx={TabStyle}
 							label="Extract"
-							{...a11yProps(3)}
+							{...a11yProps(4)}
 							disabled={false}
 						/>
 						<Tab
@@ -258,7 +268,7 @@ export const Dataset = (): JSX.Element => {
 							iconPosition="start"
 							sx={TabStyle}
 							label="Extraction History"
-							{...a11yProps(4)}
+							{...a11yProps(5)}
 							disabled={false}
 						/>
 						<Tab
@@ -266,7 +276,7 @@ export const Dataset = (): JSX.Element => {
 							iconPosition="start"
 							sx={TabStyle}
 							label="Sharing"
-							{...a11yProps(5)}
+							{...a11yProps(6)}
 							disabled={false}
 						/>
 					</Tabs>
@@ -274,6 +284,9 @@ export const Dataset = (): JSX.Element => {
 						<FilesTable datasetId={datasetId} folderId={folderId} />
 					</TabPanel>
 					<TabPanel value={selectedTabIndex} index={1}>
+						<Visualization datasetId={datasetId} />
+					</TabPanel>
+					<TabPanel value={selectedTabIndex} index={2}>
 						{enableAddMetadata ? (
 							<>
 								<EditMetadata
@@ -319,7 +332,7 @@ export const Dataset = (): JSX.Element => {
 							</>
 						)}
 					</TabPanel>
-					<TabPanel value={selectedTabIndex} index={2}>
+					<TabPanel value={selectedTabIndex} index={3}>
 						<DisplayListenerMetadata
 							updateMetadata={updateDatasetMetadata}
 							deleteMetadata={deleteDatasetMetadata}
@@ -327,13 +340,13 @@ export const Dataset = (): JSX.Element => {
 							resourceId={datasetId}
 						/>
 					</TabPanel>
-					<TabPanel value={selectedTabIndex} index={3}>
+					<TabPanel value={selectedTabIndex} index={4}>
 						<Listeners datasetId={datasetId} />
 					</TabPanel>
-					<TabPanel value={selectedTabIndex} index={4}>
+					<TabPanel value={selectedTabIndex} index={5}>
 						<ExtractionHistoryTab datasetId={datasetId} />
 					</TabPanel>
-					<TabPanel value={selectedTabIndex} index={5}>
+					<TabPanel value={selectedTabIndex} index={6}>
 						<SharingTab datasetId={datasetId} />
 					</TabPanel>
 				</Grid>

--- a/frontend/src/components/visualizations/Visualization.tsx
+++ b/frontend/src/components/visualizations/Visualization.tsx
@@ -9,9 +9,10 @@ import { Grid } from "@mui/material";
 
 type previewProps = {
 	fileId?: string;
+	datasetId?: string;
 };
 export const Visualization = (props: previewProps) => {
-	const { fileId } = props;
+	const { fileId, datasetId } = props;
 
 	const fileSummary = useSelector((state: RootState) => state.file.fileSummary);
 	const visConfig = useSelector(
@@ -26,9 +27,15 @@ export const Visualization = (props: previewProps) => {
 		dispatch(getVisConfigAction(resourceId));
 
 	useEffect(() => {
-		listFileSummary(fileId);
-		getVisConfig(fileId);
-	}, []);
+		if (fileId !== undefined) {
+			listFileSummary(fileId);
+			getVisConfig(fileId);
+		}
+
+		if (datasetId !== undefined) {
+			getVisConfig(datasetId);
+		}
+	}, [fileId, datasetId]);
 
 	return (
 		<Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 3, md: 3 }}>


### PR DESCRIPTION
To test:
1. create vis config 
POST http://127.0.0.1:8000/api/v2/visualizations/config with below body. Make sure you replace the "resource_id" with a valid dataset id
```
{
    "resource": {
        "collection": "datasets",
        "resource_id": "649ddeeb8a2aeb8d8e89fa4f"
    },
    "client": "testClient",
    "visualization_component_id": "basic-image-component",
    "parameters": {},
    "visualization_mimetype": "image/png"
}
```

2. upload image with file; replace the config id with the return config id in step 1
POST http://127.0.0.1:8000/api/v2/visualizations?name=datasetVis&description=visualization for dataset&config=64b951ec06da54df660d0d17

3. View it on dataset/ visualization tab
<img width="1790" alt="Pasted Graphic 1" src="https://github.com/clowder-framework/clowder2/assets/13950475/12caa142-f9bf-40bd-af96-bcc3b55e7444">


