### PR TITLE
600 share should have its own menu

### DIFF
--- a/frontend/src/components/datasets/ActionsMenu.tsx
+++ b/frontend/src/components/datasets/ActionsMenu.tsx
@@ -6,6 +6,7 @@ import {RootState} from "../../types/data";
 import {Download} from "@mui/icons-material";
 import {NewMenu} from "./NewMenu";
 import {OtherMenu} from "./OtherMenu";
+import {ShareMenu} from "./ShareMenu";
 import {EditMenu} from "./EditMenu";
 import {AuthWrapper} from "../auth/AuthWrapper";
 
@@ -52,6 +53,11 @@ export const ActionsMenu = (props: ActionsMenuProps): JSX.Element => {
 				</AuthWrapper>
 			}
 			{/*owner can delete and perform other tasks*/}
+			{
+				<AuthWrapper currRole={datasetRole.role} allowedRoles={["owner"]}>
+					<ShareMenu datasetId={datasetId} folderId={folderId} datasetName={datasetName}/>
+				</AuthWrapper>
+			}
 			{
 				<AuthWrapper currRole={datasetRole.role} allowedRoles={["owner"]}>
 					<OtherMenu datasetId={datasetId} folderId={folderId} datasetName={datasetName}/>

--- a/frontend/src/components/datasets/OtherMenu.tsx
+++ b/frontend/src/components/datasets/OtherMenu.tsx
@@ -35,8 +35,6 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 
 	// state
 	const [deleteDatasetConfirmOpen, setDeleteDatasetConfirmOpen] = useState(false);
-	const [sharePaneOpen, setSharePaneOpen] = useState(false);
-	const [shareGroupPaneOpen, setShareGroupPaneOpen] = useState(false);
 
 
 
@@ -60,14 +58,6 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 		setAnchorEl(null);
 	};
 
-    const handleShareClose = () => {
-        setSharePaneOpen(false);
-    }
-
-      const handleShareGroupClose = () => {
-        setShareGroupPaneOpen(false);
-    }
-
 	return (
 		<Box>
 			<ActionModal actionOpen={deleteDatasetConfirmOpen} actionTitle="Are you sure?"
@@ -76,11 +66,6 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 						 handleActionCancel={() => {
 							 setDeleteDatasetConfirmOpen(false);
 						 }}/>
-
- 		        <ShareDatasetModal open={sharePaneOpen} handleClose={handleShareClose} datasetName={datasetName}/>
-			 	<ShareGroupDatasetModal open={shareGroupPaneOpen} handleClose={handleShareGroupClose} datasetName={datasetName}/>
-
-
 			<Button variant="outlined" onClick={handleOptionClick}
 					endIcon={<ArrowDropDownIcon/>}>
 				<MoreHoriz/>
@@ -102,28 +87,6 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 						<DeleteIcon fontSize="small"/>
 					</ListItemIcon>
 					<ListItemText>Delete Dataset</ListItemText></MenuItem>
-                		<MenuItem
-                    			onClick={() => {
-                        			handleOptionClose();
-                        			setSharePaneOpen(true);
-                    			}
-                    		}>
-                    			<ListItemIcon>
-                        			<ShareIcon fontSize="small" />
-                    			</ListItemIcon>
-                    			<ListItemText>Share</ListItemText>
-                		</MenuItem>
-						<MenuItem
-                    			onClick={() => {
-                        			handleOptionClose();
-                        			setShareGroupPaneOpen(true);
-                    			}
-                    		}>
-                    			<ListItemIcon>
-                        			<ShareIcon fontSize="small" />
-                    			</ListItemIcon>
-                    			<ListItemText>Share With Group</ListItemText>
-                		</MenuItem>
 			</Menu>
 		</Box>)
 }

--- a/frontend/src/components/datasets/ShareMenu.tsx
+++ b/frontend/src/components/datasets/ShareMenu.tsx
@@ -9,6 +9,8 @@ import {useDispatch} from "react-redux";
 import {MoreHoriz} from "@material-ui/icons";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ShareIcon from '@mui/icons-material/Share';
+import GroupsIcon from "@mui/icons-material/Groups";
+import PersonIcon from "@mui/icons-material/Person";
 import ShareDatasetModal from "./ShareDatasetModal"
 import ShareGroupDatasetModal from "./ShareGroupDatasetModal";
 
@@ -98,7 +100,7 @@ export const ShareMenu = (props: ActionsMenuProps): JSX.Element => {
 							}
 						}>
 							<ListItemIcon>
-								<ShareIcon fontSize="small" />
+								<PersonIcon fontSize="small" />
 							</ListItemIcon>
 							<ListItemText>Share</ListItemText>
 					</MenuItem>
@@ -109,7 +111,7 @@ export const ShareMenu = (props: ActionsMenuProps): JSX.Element => {
 							}
 						}>
 							<ListItemIcon>
-								<ShareIcon fontSize="small" />
+								<GroupsIcon fontSize="small" />
 							</ListItemIcon>
 							<ListItemText>Share With Group</ListItemText>
 					</MenuItem>

--- a/frontend/src/components/datasets/ShareMenu.tsx
+++ b/frontend/src/components/datasets/ShareMenu.tsx
@@ -1,0 +1,118 @@
+import {Box, Button, ListItemIcon, ListItemText, Menu, MenuItem} from "@mui/material";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import React, {useEffect, useState} from "react";
+import {ActionModal} from "../dialog/ActionModal";
+import {datasetDeleted, fetchFilesInDataset} from "../../actions/dataset";
+import {fetchGroups} from "../../actions/group";
+import {useNavigate} from "react-router-dom";
+import {useDispatch} from "react-redux";
+import {MoreHoriz} from "@material-ui/icons";
+import DeleteIcon from "@mui/icons-material/Delete";
+import ShareIcon from '@mui/icons-material/Share';
+import ShareDatasetModal from "./ShareDatasetModal"
+import ShareGroupDatasetModal from "./ShareGroupDatasetModal";
+
+type ActionsMenuProps = {
+	datasetId: string,
+	datasetName: string
+}
+
+export const ShareMenu = (props: ActionsMenuProps): JSX.Element => {
+	const {datasetId, datasetName} = props;
+
+	// use history hook to redirect/navigate between routes
+	const history = useNavigate();
+
+	// redux
+	const dispatch = useDispatch();
+	const deleteDataset = (datasetId: string | undefined) => dispatch(datasetDeleted(datasetId));
+	const listGroups = () => dispatch(fetchGroups(0, 21));
+
+	// component did mount
+	useEffect(() => {
+		listGroups();
+	}, []);
+
+	// state
+	const [deleteDatasetConfirmOpen, setDeleteDatasetConfirmOpen] = useState(false);
+	const [sharePaneOpen, setSharePaneOpen] = useState(false);
+	const [shareGroupPaneOpen, setShareGroupPaneOpen] = useState(false);
+
+
+
+	// delete dataset
+	const deleteSelectedDataset = () => {
+		if (datasetId) {
+			deleteDataset(datasetId);
+		}
+		setDeleteDatasetConfirmOpen(false);
+		// Go to Explore page
+		history("/");
+	}
+
+	const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
+
+	const handleOptionClick = (event: React.MouseEvent<any>) => {
+		setAnchorEl(event.currentTarget);
+	};
+
+	const handleOptionClose = () => {
+		setAnchorEl(null);
+	};
+
+    const handleShareClose = () => {
+        setSharePaneOpen(false);
+    }
+
+      const handleShareGroupClose = () => {
+        setShareGroupPaneOpen(false);
+    }
+
+	return (
+		<Box>
+			<ActionModal actionOpen={deleteDatasetConfirmOpen} actionTitle="Are you sure?"
+						 actionText="Do you really want to delete this dataset? This process cannot be undone."
+						 actionBtnName="Delete" handleActionBtnClick={deleteSelectedDataset}
+						 handleActionCancel={() => {
+							 setDeleteDatasetConfirmOpen(false);
+						 }}/>
+
+ 		        <ShareDatasetModal open={sharePaneOpen} handleClose={handleShareClose} datasetName={datasetName}/>
+			 	<ShareGroupDatasetModal open={shareGroupPaneOpen} handleClose={handleShareGroupClose} datasetName={datasetName}/>
+
+			<Button variant="outlined" onClick={handleOptionClick}
+					endIcon={<ArrowDropDownIcon/>}>
+				Share
+			</Button>
+			<Menu
+				id="simple-menu"
+				anchorEl={anchorEl}
+				keepMounted
+				open={Boolean(anchorEl)}
+				onClose={handleOptionClose}
+			>
+					<MenuItem
+							onClick={() => {
+								handleOptionClose();
+								setSharePaneOpen(true);
+							}
+						}>
+							<ListItemIcon>
+								<ShareIcon fontSize="small" />
+							</ListItemIcon>
+							<ListItemText>Share</ListItemText>
+					</MenuItem>
+					<MenuItem
+							onClick={() => {
+								handleOptionClose();
+								setShareGroupPaneOpen(true);
+							}
+						}>
+							<ListItemIcon>
+								<ShareIcon fontSize="small" />
+							</ListItemIcon>
+							<ListItemText>Share With Group</ListItemText>
+					</MenuItem>
+			</Menu>
+		</Box>)
+}


### PR DESCRIPTION
Sharing is now in its own menu. The icons used are for person and group. OtherMenu now just deletes. Was wondering if that OtherMenu should be replaced by just a button for delete now that it only does one thing? 
<img width="1045" alt="Screenshot 2023-07-20 at 5 29 39 PM" src="https://github.com/clowder-framework/clowder2/assets/40038535/4107c90d-fb82-4c87-b4e2-992bffa45ed4">
