### PR TITLE
fix logout

### DIFF
--- a/backend/app/routers/keycloak.py
+++ b/backend/app/routers/keycloak.py
@@ -49,7 +49,7 @@ async def logout(
         ) is not None:
             # log user out
             try:
-                keycloak_openid.logout(token_exist["refresh_token"])
+                keycloak_openid.logout(token_exist.refresh_token)
 
                 # delete entry in the token database
                 await token_exist.delete()


### PR DESCRIPTION
logout was failing since token_exist is now an object, not a dict. So when it tried to find token_exist["refresh_token"] nothing was there. 