### PR TITLE
597 edit group name and description

### DIFF
--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -121,7 +121,9 @@ async def edit_group(
         for original_user in original_users:
             if original_user not in groups_users:
                 # remove them from auth
-                async for auth in AuthorizationDB.find({"group_ids": ObjectId(group_id)}):
+                async for auth in AuthorizationDB.find(
+                    {"group_ids": ObjectId(group_id)}
+                ):
                     auth.user_ids.remove(original_user.user.email)
                     await auth.replace()
                     # Update group itself

--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -112,8 +112,8 @@ async def edit_group(
             return
 
         user = await UserDB.find_one(UserDB.email == user_id)
-        group_dict["creator"] = UserOut(**user)
-        group_dict["modified"] = datetime.datetime.utcnow()
+        group_dict["creator"] = user.dict()
+        group_dict["modified"] = datetime.utcnow()
         # TODO: Revisit this. Authorization needs to be updated here.
         group_dict["users"] = list(set(group_dict["users"]))
         try:

--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -155,6 +155,9 @@ async def edit_group(
         try:
             group.name = group_dict["name"]
             await group.replace()
+            if "description" in group_dict:
+                group.description = group_dict["description"]
+                await group.replace()
         except Exception as e:
             raise HTTPException(status_code=500, detail=e.args[0])
         return group.dict()

--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -104,7 +104,7 @@ async def edit_group(
     if (group := await GroupDB.get(PydanticObjectId(group_id))) is not None:
         group_dict = dict(group_info) if group_info is not None else {}
 
-        if len(group_dict.name) == 0 or len(group_dict.users) == 0:
+        if len(group_dict["name"]) == 0 or len(group_dict["users"]) == 0:
             raise HTTPException(
                 status_code=400,
                 detail="Group name can't be null or user list can't be empty",

--- a/frontend/src/actions/group.js
+++ b/frontend/src/actions/group.js
@@ -163,3 +163,24 @@ export function assignGroupMemberRole(groupId, username, role = "viewer") {
 			});
 	};
 }
+
+export const UPDATE_GROUP = "UPDATE_GROUP";
+
+export function updateGroup(groupId, formData) {
+	return (dispatch) => {
+		return V2.GroupsService.editGroupApiV2GroupsGroupIdPut(
+			groupId,
+			formData
+		)
+			.then((json) => {
+				dispatch({
+					type: UPDATE_GROUP,
+					about: json,
+					receivedAt: Date.now(),
+				});
+			})
+			.catch((reason) => {
+				dispatch(handleErrors(reason, updateGroup(groupId, formData)));
+			});
+	};
+}

--- a/frontend/src/components/groups/EditDescriptionModal.tsx
+++ b/frontend/src/components/groups/EditDescriptionModal.tsx
@@ -1,0 +1,87 @@
+
+import React, { useEffect, useState } from "react";
+import {
+	Autocomplete,
+	Button,
+	Container,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	TextField,
+} from "@mui/material";
+import {updateGroup} from "../../actions/group";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../../types/data";
+import {GroupIn} from "../../openapi/v2";
+import GroupsIcon from "@mui/icons-material/Groups";
+import { InlineAlert } from "../errors/InlineAlert";
+import { resetFailedReasonInline } from "../../actions/common";
+import LoadingOverlay from "react-loading-overlay-ts";
+
+type EditDescriptionModalProps = {
+	open: boolean;
+	handleClose: any;
+	groupOwner: string;
+	groupDescription: string;
+	groupId: string | undefined;
+};
+
+
+export default function EditNameModal(props: EditDescriptionModalProps) {
+	const {open, handleClose, groupOwner, groupDescription, groupId} = props;
+	const dispatch = useDispatch();
+	const editGroup = (groupId: string | undefined, formData: GroupIn) => dispatch(updateGroup(groupId, formData));
+
+	const groupAbout = useSelector((state: RootState) => state.group.about);
+	const about = useSelector((state: RootState) => state.dataset.about);
+
+	const [loading, setLoading] = useState(false);
+	const [description, setDescription] = useState(groupDescription);
+
+
+
+	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setName(event.target.value);
+	};
+
+	const handleDialogClose = () => {
+		handleClose();
+		dispatch(resetFailedReasonInline());
+	};
+
+	const onSave = async () => {
+		setLoading(true);
+		editGroup(groupId, {"description": description, "users": groupAbout.users});
+		setDescription("");
+		setLoading(false);
+		handleDialogClose();
+	};
+
+	return (
+		<Container>
+			<LoadingOverlay
+				active={loading}
+				spinner
+				text="Saving..."
+			>
+				<Dialog open={open} onClose={handleClose} fullWidth={true}>
+					<DialogTitle>Change Group Description</DialogTitle>
+					<DialogContent>
+							<TextField
+								id="outlined-name"
+								variant="standard"
+								fullWidth
+								defaultValue={groupDescription}
+								onChange={handleChange}
+							/>
+					</DialogContent>
+					<DialogActions>
+						<Button variant="contained" onClick={onSave} disabled={description == ""}>Save</Button>
+						<Button onClick={handleDialogClose}>Cancel</Button>
+					</DialogActions>
+				</Dialog>
+			</LoadingOverlay>
+		</Container>
+	);
+}

--- a/frontend/src/components/groups/EditDescriptionModal.tsx
+++ b/frontend/src/components/groups/EditDescriptionModal.tsx
@@ -23,7 +23,7 @@ type EditDescriptionModalProps = {
 	open: boolean;
 	handleClose: any;
 	groupOwner: string;
-	groupDescription: string;
+	groupDescription: string | undefined;
 	groupId: string | undefined;
 };
 
@@ -42,7 +42,7 @@ export default function EditNameModal(props: EditDescriptionModalProps) {
 
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-		setName(event.target.value);
+		setDescription(event.target.value);
 	};
 
 	const handleDialogClose = () => {

--- a/frontend/src/components/groups/EditDescriptionModal.tsx
+++ b/frontend/src/components/groups/EditDescriptionModal.tsx
@@ -24,12 +24,13 @@ type EditDescriptionModalProps = {
 	handleClose: any;
 	groupOwner: string;
 	groupDescription: string | undefined;
+	groupName: string | undefined;
 	groupId: string | undefined;
 };
 
 
 export default function EditNameModal(props: EditDescriptionModalProps) {
-	const {open, handleClose, groupOwner, groupDescription, groupId} = props;
+	const {open, handleClose, groupOwner, groupName, groupDescription, groupId} = props;
 	const dispatch = useDispatch();
 	const editGroup = (groupId: string | undefined, formData: GroupIn) => dispatch(updateGroup(groupId, formData));
 
@@ -52,7 +53,7 @@ export default function EditNameModal(props: EditDescriptionModalProps) {
 
 	const onSave = async () => {
 		setLoading(true);
-		editGroup(groupId, {"description": description, "users": groupAbout.users});
+		editGroup(groupId, {"name": groupName,"description": description, "users": groupAbout.users});
 		setDescription("");
 		setLoading(false);
 		handleDialogClose();

--- a/frontend/src/components/groups/EditMenu.tsx
+++ b/frontend/src/components/groups/EditMenu.tsx
@@ -16,7 +16,7 @@ type ActionsMenuProps = {
 }
 
 export const EditMenu = (props: ActionsMenuProps): JSX.Element => {
-	const {groupOwner, groupname, groupId} = props;
+	const {groupOwner, groupName, groupId} = props;
 
 	const dispatch = useDispatch();
 	const editGroup = (groupId: string | undefined, formData: GroupIn) => dispatch(updateGroup(groupId, formData));
@@ -60,15 +60,15 @@ export const EditMenu = (props: ActionsMenuProps): JSX.Element => {
 				groupName={groupAbout.name}
 				groupId={groupAbout.id}
 			/>
-			<EditDescriptionModal
-				open={editNameModalOpen}
-				groupOwner={groupCreatorEmail}
-				handleClose={() => {
-					setEditNameModalOpen(false);
-				}}
-				groupDescription={groupAbout.description}
-				groupId={groupAbout.id}
-			/>
+			{/*<EditDescriptionModal*/}
+			{/*	open={editNameModalOpen}*/}
+			{/*	groupOwner={groupCreatorEmail}*/}
+			{/*	handleClose={() => {*/}
+			{/*		setEditDescriptionModalOpen(false);*/}
+			{/*	}}*/}
+			{/*	groupDescription={groupAbout.description}*/}
+			{/*	groupId={groupAbout.id}*/}
+			{/*/>*/}
 			<Button variant="outlined" onClick={handleOptionClick}
 					endIcon={<ArrowDropDownIcon/>}>
 				Edit

--- a/frontend/src/components/groups/EditMenu.tsx
+++ b/frontend/src/components/groups/EditMenu.tsx
@@ -1,0 +1,103 @@
+import {Box, Button, ListItemIcon, ListItemText, Menu, MenuItem} from "@mui/material";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import React, {useState} from "react";
+import EditNameModal from "./EditNameModal";
+import EditDescriptionModal from "./EditDescriptionModal";
+import {DriveFileRenameOutline} from "@mui/icons-material";
+import {useDispatch, useSelector} from "react-redux";
+import {GroupIn} from "../../openapi/v2";
+import {updateGroup} from "../../actions/group";
+import {RootState} from "../../types/data";
+
+type ActionsMenuProps = {
+	groupOwner: string;
+	groupName: string;
+	groupId: string | undefined;
+}
+
+export const EditMenu = (props: ActionsMenuProps): JSX.Element => {
+	const {groupOwner, groupname, groupId} = props;
+
+	const dispatch = useDispatch();
+	const editGroup = (groupId: string | undefined, formData: GroupIn) => dispatch(updateGroup(groupId, formData));
+
+	const groupAbout = useSelector((state: RootState) => state.group.about);
+	const about = useSelector((state: RootState) => state.dataset.about);
+
+	const groupCreatorEmail = useSelector(
+		(state: RootState) => state.group.about.creator
+	);
+
+	// state
+	const [rename, setRename] = React.useState<boolean>(false);
+	const [description, setDescription] = React.useState<boolean>(false);
+	const [editNameModalOpen, setEditNameModalOpen] = useState(false);
+	const [editDescriptionModalOpen, setEditDescriptionModalOpen] = useState(false);
+
+	const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
+
+	const handleOptionClick = (event: React.MouseEvent<any>) => {
+		setAnchorEl(event.currentTarget);
+	};
+
+	const handleOptionClose = () => {
+		setAnchorEl(null);
+	};
+	const handleSetRename = () => {
+		setRename(false);
+	}
+	const handleSetDescription = () => {
+		setDescription(false);
+	}
+	return (
+		<Box>
+			<EditNameModal
+				open={editNameModalOpen}
+				groupOwner={groupCreatorEmail}
+				handleClose={() => {
+					setEditNameModalOpen(false);
+				}}
+				groupName={groupAbout.name}
+				groupId={groupAbout.id}
+			/>
+			<EditDescriptionModal
+				open={editNameModalOpen}
+				groupOwner={groupCreatorEmail}
+				handleClose={() => {
+					setEditNameModalOpen(false);
+				}}
+				groupDescription={groupAbout.description}
+				groupId={groupAbout.id}
+			/>
+			<Button variant="outlined" onClick={handleOptionClick}
+					endIcon={<ArrowDropDownIcon/>}>
+				Edit
+			</Button>
+			<Menu
+				id="simple-menu"
+				anchorEl={anchorEl}
+				keepMounted
+				open={Boolean(anchorEl)}
+				onClose={handleOptionClose}
+			>
+				<MenuItem
+					onClick={() => {
+						handleOptionClose();
+						setRename(true);
+					}
+					}> <ListItemIcon>
+					<DriveFileRenameOutline fontSize="small"/>
+				</ListItemIcon>
+					<ListItemText>Rename</ListItemText></MenuItem>
+				<MenuItem
+					onClick={() => {
+						handleOptionClose();
+						setDescription(true);
+					}
+					}> <ListItemIcon>
+					<DriveFileRenameOutline fontSize="small"/>
+				</ListItemIcon>
+					<ListItemText>Update Description</ListItemText></MenuItem>
+			</Menu>
+		</Box>)
+}

--- a/frontend/src/components/groups/EditMenu.tsx
+++ b/frontend/src/components/groups/EditMenu.tsx
@@ -60,15 +60,15 @@ export const EditMenu = (props: ActionsMenuProps): JSX.Element => {
 				groupName={groupAbout.name}
 				groupId={groupAbout.id}
 			/>
-			{/*<EditDescriptionModal*/}
-			{/*	open={editNameModalOpen}*/}
-			{/*	groupOwner={groupCreatorEmail}*/}
-			{/*	handleClose={() => {*/}
-			{/*		setEditDescriptionModalOpen(false);*/}
-			{/*	}}*/}
-			{/*	groupDescription={groupAbout.description}*/}
-			{/*	groupId={groupAbout.id}*/}
-			{/*/>*/}
+			<EditDescriptionModal
+				open={editDescriptionModalOpen}
+				groupOwner={groupCreatorEmail}
+				handleClose={() => {
+					setEditDescriptionModalOpen(false);
+				}}
+				groupDescription={groupAbout.description}
+				groupId={groupAbout.id}
+			/>
 			<Button variant="outlined" onClick={handleOptionClick}
 					endIcon={<ArrowDropDownIcon/>}>
 				Edit
@@ -92,7 +92,7 @@ export const EditMenu = (props: ActionsMenuProps): JSX.Element => {
 				<MenuItem
 					onClick={() => {
 						handleOptionClose();
-						setDescription(true);
+						setEditDescriptionModalOpen(true);
 					}
 					}> <ListItemIcon>
 					<DriveFileRenameOutline fontSize="small"/>

--- a/frontend/src/components/groups/EditMenu.tsx
+++ b/frontend/src/components/groups/EditMenu.tsx
@@ -83,9 +83,10 @@ export const EditMenu = (props: ActionsMenuProps): JSX.Element => {
 				<MenuItem
 					onClick={() => {
 						handleOptionClose();
-						setRename(true);
+						setEditNameModalOpen(true);
 					}
-					}> <ListItemIcon>
+					}>
+				<ListItemIcon>
 					<DriveFileRenameOutline fontSize="small"/>
 				</ListItemIcon>
 					<ListItemText>Rename</ListItemText></MenuItem>

--- a/frontend/src/components/groups/EditMenu.tsx
+++ b/frontend/src/components/groups/EditMenu.tsx
@@ -66,6 +66,7 @@ export const EditMenu = (props: ActionsMenuProps): JSX.Element => {
 				handleClose={() => {
 					setEditDescriptionModalOpen(false);
 				}}
+				groupName={groupAbout.name}
 				groupDescription={groupAbout.description}
 				groupId={groupAbout.id}
 			/>

--- a/frontend/src/components/groups/EditNameModal.tsx
+++ b/frontend/src/components/groups/EditNameModal.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+import {
+	Autocomplete,
+	Button,
+	Container,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	TextField,
+} from "@mui/material";
+import { addGroupMember } from "../../actions/group";
+import { useDispatch, useSelector } from "react-redux";
+import { prefixSearchAllUsers as prefixSearchAllUsersAction } from "../../actions/user";
+import { RootState } from "../../types/data";
+import {DatasetIn, UserOut} from "../../openapi/v2";
+import GroupsIcon from "@mui/icons-material/Groups";
+import { InlineAlert } from "../errors/InlineAlert";
+import { resetFailedReasonInline } from "../../actions/common";
+import {updateDataset} from "../../actions/dataset";
+import LoadingOverlay from "react-loading-overlay-ts";
+
+type EditNameModalProps = {
+	open: boolean;
+	handleClose: any;
+	groupName: string;
+	groupId: string | undefined;
+};
+
+
+export default function EditNameModal(props: EditNameModalProps) {
+	const {open, handleClose, groupName, groupId} = props;
+	const dispatch = useDispatch();
+	const editGroup = (datasetId: string | undefined, formData: DatasetIn) => dispatch(updateDataset(datasetId, formData));
+
+
+	const about = useSelector((state: RootState) => state.dataset.about);
+
+	const [loading, setLoading] = useState(false);
+	const [name, setName] = useState(about["name"]);
+
+
+
+	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setName(event.target.value);
+	};
+
+	const onSave = async () => {
+		setLoading(true);
+		editGroup(groupId, {"name": name});
+		setName("");
+		setLoading(false);
+		handleClose(true);
+	};
+
+	return (
+		<Container>
+			<LoadingOverlay
+				active={loading}
+				spinner
+				text="Saving..."
+			>
+				<Dialog open={open} onClose={handleClose} fullWidth={true}>
+					<DialogTitle>Rename Group</DialogTitle>
+					<DialogContent>
+							<TextField
+								id="outlined-name"
+								variant="standard"
+								fullWidth
+								defaultValue={about["name"]}
+								onChange={handleChange}
+							/>
+					</DialogContent>
+					<DialogActions>
+						<Button variant="contained" onClick={onSave} disabled={name == ""}>Save</Button>
+						<Button onClick={handleClose}>Cancel</Button>
+					</DialogActions>
+				</Dialog>
+			</LoadingOverlay>
+		</Container>
+	);
+}

--- a/frontend/src/components/groups/EditNameModal.tsx
+++ b/frontend/src/components/groups/EditNameModal.tsx
@@ -36,7 +36,7 @@ export default function EditNameModal(props: EditNameModalProps) {
 	const about = useSelector((state: RootState) => state.dataset.about);
 
 	const [loading, setLoading] = useState(false);
-	const [name, setName] = useState(about["name"]);
+	const [name, setName] = useState(groupName);
 
 
 
@@ -51,6 +51,7 @@ export default function EditNameModal(props: EditNameModalProps) {
 
 	const onSave = async () => {
 		setLoading(true);
+		console.log(groupId, groupName,"oldname", name,'newname')
 		editGroup(groupId, {"name": name});
 		setName("");
 		setLoading(false);
@@ -70,7 +71,7 @@ export default function EditNameModal(props: EditNameModalProps) {
 								id="outlined-name"
 								variant="standard"
 								fullWidth
-								defaultValue={about["name"]}
+								defaultValue={groupName}
 								onChange={handleChange}
 							/>
 					</DialogContent>

--- a/frontend/src/components/groups/EditNameModal.tsx
+++ b/frontend/src/components/groups/EditNameModal.tsx
@@ -32,7 +32,7 @@ export default function EditNameModal(props: EditNameModalProps) {
 	const dispatch = useDispatch();
 	const editGroup = (groupId: string | undefined, formData: GroupIn) => dispatch(updateGroup(groupId, formData));
 
-
+	const groupAbout = useSelector((state: RootState) => state.group.about);
 	const about = useSelector((state: RootState) => state.dataset.about);
 
 	const [loading, setLoading] = useState(false);
@@ -52,7 +52,7 @@ export default function EditNameModal(props: EditNameModalProps) {
 	const onSave = async () => {
 		setLoading(true);
 		console.log(groupId, groupName,"oldname", name,'newname')
-		editGroup(groupId, {"name": name});
+		editGroup(groupId, {"name": name, "users": groupAbout.users});
 		setName("");
 		setLoading(false);
 	};

--- a/frontend/src/components/groups/EditNameModal.tsx
+++ b/frontend/src/components/groups/EditNameModal.tsx
@@ -51,7 +51,6 @@ export default function EditNameModal(props: EditNameModalProps) {
 
 	const onSave = async () => {
 		setLoading(true);
-		console.log(groupId, groupName,"oldname", name,'newname')
 		editGroup(groupId, {"name": name, "users": groupAbout.users});
 		setName("");
 		setLoading(false);

--- a/frontend/src/components/groups/EditNameModal.tsx
+++ b/frontend/src/components/groups/EditNameModal.tsx
@@ -55,6 +55,7 @@ export default function EditNameModal(props: EditNameModalProps) {
 		editGroup(groupId, {"name": name, "users": groupAbout.users});
 		setName("");
 		setLoading(false);
+		handleDialogClose();
 	};
 
 	return (

--- a/frontend/src/components/groups/EditNameModal.tsx
+++ b/frontend/src/components/groups/EditNameModal.tsx
@@ -9,29 +9,28 @@ import {
 	DialogTitle,
 	TextField,
 } from "@mui/material";
-import { addGroupMember } from "../../actions/group";
+import {updateGroup} from "../../actions/group";
 import { useDispatch, useSelector } from "react-redux";
-import { prefixSearchAllUsers as prefixSearchAllUsersAction } from "../../actions/user";
 import { RootState } from "../../types/data";
-import {DatasetIn, UserOut} from "../../openapi/v2";
+import {GroupIn} from "../../openapi/v2";
 import GroupsIcon from "@mui/icons-material/Groups";
 import { InlineAlert } from "../errors/InlineAlert";
 import { resetFailedReasonInline } from "../../actions/common";
-import {updateDataset} from "../../actions/dataset";
 import LoadingOverlay from "react-loading-overlay-ts";
 
 type EditNameModalProps = {
 	open: boolean;
 	handleClose: any;
+	groupOwner: string;
 	groupName: string;
 	groupId: string | undefined;
 };
 
 
 export default function EditNameModal(props: EditNameModalProps) {
-	const {open, handleClose, groupName, groupId} = props;
+	const {open, handleClose, groupOwner, groupName, groupId} = props;
 	const dispatch = useDispatch();
-	const editGroup = (datasetId: string | undefined, formData: DatasetIn) => dispatch(updateDataset(datasetId, formData));
+	const editGroup = (groupId: string | undefined, formData: GroupIn) => dispatch(updateGroup(groupId, formData));
 
 
 	const about = useSelector((state: RootState) => state.dataset.about);
@@ -45,12 +44,16 @@ export default function EditNameModal(props: EditNameModalProps) {
 		setName(event.target.value);
 	};
 
+	const handleDialogClose = () => {
+		handleClose();
+		dispatch(resetFailedReasonInline());
+	};
+
 	const onSave = async () => {
 		setLoading(true);
 		editGroup(groupId, {"name": name});
 		setName("");
 		setLoading(false);
-		handleClose(true);
 	};
 
 	return (
@@ -73,7 +76,7 @@ export default function EditNameModal(props: EditNameModalProps) {
 					</DialogContent>
 					<DialogActions>
 						<Button variant="contained" onClick={onSave} disabled={name == ""}>Save</Button>
-						<Button onClick={handleClose}>Cancel</Button>
+						<Button onClick={handleDialogClose}>Cancel</Button>
 					</DialogActions>
 				</Dialog>
 			</LoadingOverlay>

--- a/frontend/src/components/groups/Group.tsx
+++ b/frontend/src/components/groups/Group.tsx
@@ -92,8 +92,9 @@ export function Group() {
 			/>
 			<EditNameModal
 				open={editNameModalOpen}
+				groupOwner={groupCreatorEmail}
 				handleClose={() => {
-					setAddMemberModalOpen(false);
+					setEditNameModalOpen(false);
 				}}
 				groupName={groupAbout.name}
 				groupId={groupAbout.id}

--- a/frontend/src/components/groups/Group.tsx
+++ b/frontend/src/components/groups/Group.tsx
@@ -168,18 +168,18 @@ export function Group() {
 					</AuthWrapper>
 
 
-					<AuthWrapper currRole={role} allowedRoles={["owner"]}>
-						<Button
-							variant="outlined"
-							onClick={() => {
-								setEditNameModalOpen(true);
-							}}
-							endIcon={<DriveFileRenameOutline fontSize="small"/>}
-							sx={{ marginLeft: "0.5em" }}
-						>
-							Edit Name
-						</Button>
-					</AuthWrapper>
+					{/*<AuthWrapper currRole={role} allowedRoles={["owner"]}>*/}
+					{/*	<Button*/}
+					{/*		variant="outlined"*/}
+					{/*		onClick={() => {*/}
+					{/*			setEditNameModalOpen(true);*/}
+					{/*		}}*/}
+					{/*		endIcon={<DriveFileRenameOutline fontSize="small"/>}*/}
+					{/*		sx={{ marginLeft: "0.5em" }}*/}
+					{/*	>*/}
+					{/*		Edit Name*/}
+					{/*	</Button>*/}
+					{/*</AuthWrapper>*/}
 					{/*only owner are allowed to delete*/}
 					<AuthWrapper currRole={role} allowedRoles={["owner"]}>
 						<Button

--- a/frontend/src/components/groups/Group.tsx
+++ b/frontend/src/components/groups/Group.tsx
@@ -10,6 +10,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { AuthWrapper } from "../auth/AuthWrapper";
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
 import MembersTable from "./MembersTable";
+import EditMenu from "./EditMenu";
 import AddMemberModal from "./AddMemberModal";
 import EditNameModal from "./EditNameModal";
 import RoleChip from "../auth/RoleChip";

--- a/frontend/src/components/groups/Group.tsx
+++ b/frontend/src/components/groups/Group.tsx
@@ -17,6 +17,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import { MainBreadcrumbs } from "../navigation/BreadCrumb";
 import { config } from "../../app.config";
 import { ErrorModal } from "../errors/ErrorModal";
+import {DriveFileRenameOutline} from "@mui/icons-material";
 
 export function Group() {
 	// path parameter
@@ -165,7 +166,7 @@ export function Group() {
 							onClick={() => {
 								setEditNameModalOpen(true);
 							}}
-							endIcon={<PersonAddAlt1Icon />}
+							endIcon={<DriveFileRenameOutline fontSize="small"/>}
 							sx={{ marginLeft: "0.5em" }}
 						>
 							Edit Name

--- a/frontend/src/components/groups/Group.tsx
+++ b/frontend/src/components/groups/Group.tsx
@@ -10,7 +10,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { AuthWrapper } from "../auth/AuthWrapper";
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
 import MembersTable from "./MembersTable";
-import EditMenu from "./EditMenu";
+import {EditMenu} from "./EditMenu";
 import AddMemberModal from "./AddMemberModal";
 import EditNameModal from "./EditNameModal";
 import RoleChip from "../auth/RoleChip";
@@ -160,6 +160,13 @@ export function Group() {
 							Add Member
 						</Button>
 					</AuthWrapper>
+					<AuthWrapper currRole={role} allowedRoles={["owner", "editor"]}>
+						<EditMenu groupOwner={groupCreatorEmail}
+								  groupName={groupAbout.name}
+								  groupId={groupId}
+						/>
+					</AuthWrapper>
+
 
 					<AuthWrapper currRole={role} allowedRoles={["owner"]}>
 						<Button

--- a/frontend/src/components/groups/Group.tsx
+++ b/frontend/src/components/groups/Group.tsx
@@ -11,6 +11,7 @@ import { AuthWrapper } from "../auth/AuthWrapper";
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
 import MembersTable from "./MembersTable";
 import AddMemberModal from "./AddMemberModal";
+import EditNameModal from "./EditNameModal";
 import RoleChip from "../auth/RoleChip";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { MainBreadcrumbs } from "../navigation/BreadCrumb";
@@ -42,6 +43,7 @@ export function Group() {
 	);
 	const groupCreatorEmailLink = "mailto:" + groupCreatorEmail;
 	const [addMemberModalOpen, setAddMemberModalOpen] = useState(false);
+	const [editNameModalOpen, setEditNameModalOpen] = useState(false);
 	const [deleteGroupConfirmOpen, setDeleteGroupConfirmOpen] = useState(false);
 
 	// component did mount
@@ -85,6 +87,14 @@ export function Group() {
 					setAddMemberModalOpen(false);
 				}}
 				groupOwner={groupCreatorEmail}
+				groupName={groupAbout.name}
+				groupId={groupAbout.id}
+			/>
+			<EditNameModal
+				open={editNameModalOpen}
+				handleClose={() => {
+					setAddMemberModalOpen(false);
+				}}
 				groupName={groupAbout.name}
 				groupId={groupAbout.id}
 			/>
@@ -145,6 +155,19 @@ export function Group() {
 							endIcon={<PersonAddAlt1Icon />}
 						>
 							Add Member
+						</Button>
+					</AuthWrapper>
+
+					<AuthWrapper currRole={role} allowedRoles={["owner"]}>
+						<Button
+							variant="outlined"
+							onClick={() => {
+								setEditNameModalOpen(true);
+							}}
+							endIcon={<PersonAddAlt1Icon />}
+							sx={{ marginLeft: "0.5em" }}
+						>
+							Edit Name
 						</Button>
 					</AuthWrapper>
 					{/*only owner are allowed to delete*/}

--- a/frontend/src/reducers/group.ts
+++ b/frontend/src/reducers/group.ts
@@ -7,6 +7,7 @@ import {
 	RECEIVE_GROUP_ABOUT,
 	RECEIVE_GROUPS,
 	SEARCH_GROUPS,
+	UPDATE_GROUP,
 } from "../actions/group";
 import { RECEIVE_GROUP_ROLE } from "../actions/authorization";
 import { DataAction } from "../types/action";
@@ -36,6 +37,8 @@ const group = (state = defaultState, action: DataAction) => {
 		case RECEIVE_GROUP_ROLE:
 			return Object.assign({}, state, { role: action.role });
 		case DELETE_GROUP_MEMBER:
+			return Object.assign({}, state, { about: action.about });
+		case UPDATE_GROUP:
 			return Object.assign({}, state, { about: action.about });
 		case ADD_GROUP_MEMBER:
 			return Object.assign({}, state, { about: action.about });


### PR DESCRIPTION
We can now edit the name of a group.

Additionally, the edit_group route should now handle all cases of adding users, removing users, or changing editor value for users. 