### PR TITLE
Fixed submission to extractors in prod

### DIFF
--- a/.run/Docker Dev.run.xml
+++ b/.run/Docker Dev.run.xml
@@ -4,6 +4,7 @@
       <settings>
         <option name="composeProjectName" value="clowder2-dev" />
         <option name="envFilePath" value="" />
+        <option name="commandLineOptions" value="--build" />
         <option name="sourceFilePath" value="docker-compose.dev.yml" />
       </settings>
     </deployment>

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -73,9 +73,6 @@ class Settings(BaseSettings):
     RABBITMQ_USER: str = "guest"
     RABBITMQ_PASS: str = "guest"
     RABBITMQ_HOST: str = "127.0.0.1"
-    RABBITMQ_URL: str = (
-        "amqp://" + RABBITMQ_USER + ":" + RABBITMQ_PASS + "@" + RABBITMQ_HOST + "/"
-    )
     HEARTBEAT_EXCHANGE: str = "extractors"
 
 

--- a/backend/app/rabbitmq/listeners.py
+++ b/backend/app/rabbitmq/listeners.py
@@ -59,7 +59,6 @@ async def submit_file_job(
     token: str = Depends(get_token),
 ):
     # Create an entry in job history with unique ID
-    print("IN_submit_file_job")
     job = EventListenerJobDB(
         listener_id=routing_key,
         creator=user,

--- a/backend/app/rabbitmq/listeners.py
+++ b/backend/app/rabbitmq/listeners.py
@@ -23,10 +23,7 @@ from app.routers.users import get_user_job_key
 
 
 async def create_reply_queue():
-    credentials = pika.PlainCredentials("guest", "guest")
-    parameters = pika.ConnectionParameters("localhost", credentials=credentials)
-    connection = pika.BlockingConnection(parameters)
-    channel = connection.channel()
+    channel: BlockingChannel = dependencies.get_rabbitmq()
 
     if (
         config_entry := await ConfigEntryDB.find_one({"key": "instance_id"})
@@ -62,6 +59,7 @@ async def submit_file_job(
     token: str = Depends(get_token),
 ):
     # Create an entry in job history with unique ID
+    print("IN_submit_file_job")
     job = EventListenerJobDB(
         listener_id=routing_key,
         creator=user,
@@ -82,6 +80,7 @@ async def submit_file_job(
         job_id=str(job.id),
     )
     reply_to = await create_reply_queue()
+    print("RABBITMQ_CLIENT: " + str(rabbitmq_client))
     rabbitmq_client.basic_publish(
         exchange="",
         routing_key=routing_key,

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -348,7 +348,7 @@ async def get_file_versions(
 
 # submits file to extractor
 @router.post("/{file_id}/extract")
-async def get_file_extract(
+async def post_file_extract(
     file_id: str,
     extractorName: str,
     # parameters don't have a fixed model shape

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ x-minio-common: &minio-common
 
 services:
 
-  reverse-proxy:
+  traefik:
     image: traefik:v2.5
     restart: unless-stopped
     command:
@@ -46,7 +46,9 @@ services:
     environment:
       MONGODB_URL: mongodb://mongo:27017
       MINIO_SERVER_URL: minio-nginx:9000
-      RABBITMQ_HOST: rabbitmq:15672
+      RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_PASS: ${RABBITMQ_PASS:-guest}
       elasticsearch_url: http://elasticsearch:9200
       auth_base: http://localhost
       auth_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
@@ -61,6 +63,7 @@ services:
       - minio-nginx
       - keycloak
       - elasticsearch
+      - rabbitmq
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.backend.rule=PathPrefix(`/api`)"
@@ -88,16 +91,16 @@ services:
   extractors-heartbeat:
     image: "clowder/clowder2-heartbeat"
     build:
-      context: ./backend
+      context: backend
       dockerfile: heartbeat.Dockerfile
     networks:
       - clowder2
     restart: unless-stopped
     environment:
-      - MONGODB_URL=mongodb://mongo:27017
-      - RABBITMQ_HOST=rabbitmq
-      - RABBITMQ_USER=${RABBITMQ_USER:-guest}
-      - RABBITMQ_PASS=${RABBITMQ_PASS:-guest}
+      MONGODB_URL: mongodb://mongo:27017
+      RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_PASS: ${RABBITMQ_PASS:-guest}
     depends_on:
       - mongo
       - rabbitmq
@@ -105,13 +108,13 @@ services:
   extractors-messages:
     image: "clowder/clowder2-messages"
     build:
-      context: ./backend
+      context: backend
       dockerfile: messages.Dockerfile
     environment:
-      - MONGODB_URL=mongodb://mongo:27017
-      - RABBITMQ_HOST=rabbitmq
-      - RABBITMQ_USER=${RABBITMQ_USER:-guest}
-      - RABBITMQ_PASS=${RABBITMQ_PASS:-guest}
+      MONGODB_URL: mongodb://mongo:27017
+      RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_PASS: ${RABBITMQ_PASS:-guest}
     networks:
       - clowder2
     restart: unless-stopped
@@ -215,11 +218,20 @@ services:
     image: rabbitmq:3-management-alpine
     environment:
       - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_management path_prefix "/rabbitmq"
-      - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER:-guest}
-      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS:-guest}
+      - RABBITMQ_DEFAULT_USER=${RABBITMQ_USER:-guest}
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASS:-guest}
+    expose:
+      - 5672
+      - 15672
+    # TODO remove
     ports:
       - "5672:5672"
       - "15672:15672"
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "5672" ]
+      interval: 3s
+      timeout: 10s
+      retries: 3
     networks:
       - clowder2
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
       RABBITMQ_USER: ${RABBITMQ_USER:-guest}
       RABBITMQ_PASS: ${RABBITMQ_PASS:-guest}
+      API_HOST: ${API_HOST:-http://localhost}
       elasticsearch_url: http://elasticsearch:9200
       auth_base: http://localhost
       auth_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code

--- a/frontend/src/actions/file.js
+++ b/frontend/src/actions/file.js
@@ -210,7 +210,7 @@ export function fileDownloaded(
 			filename = `${fileId}.zip`;
 		}
 		let endpoint = `${config.hostname}/api/v2/files/${fileId}`;
-		if (fileVersionNum != 0) endpoint = endpoint + "?version=" + fileVersionNum;
+		if (fileVersionNum != 0) endpoint = `${endpoint}?version=${fileVersionNum}`;
 		const response = await fetch(endpoint, {
 			method: "GET",
 			mode: "cors",
@@ -252,7 +252,7 @@ export const SUBMIT_FILE_EXTRACTION = "SUBMIT_FILE_EXTRACTION";
 
 export function submitFileExtractionAction(fileId, extractorName, requestBody) {
 	return (dispatch) => {
-		return V2.FilesService.getFileExtractApiV2FilesFileIdExtractPost(
+		return V2.FilesService.postFileExtractApiV2FilesFileIdExtractPost(
 			fileId,
 			extractorName,
 			requestBody
@@ -280,7 +280,7 @@ export const GENERATE_FILE_URL = "GENERATE_FILE_URL";
 export function generateFileDownloadUrl(fileId, fileVersionNum = 0) {
 	return async (dispatch) => {
 		let url = `${config.hostname}/api/v2/files/${fileId}`;
-		if (fileVersionNum > 0) url = url + "?version=" + fileVersionNum;
+		if (fileVersionNum > 0) url = `${url}?version=${fileVersionNum}`;
 
 		const response = await fetch(url, {
 			method: "GET",

--- a/frontend/src/openapi/v2/services/FilesService.ts
+++ b/frontend/src/openapi/v2/services/FilesService.ts
@@ -117,14 +117,14 @@ export class FilesService {
     }
 
     /**
-     * Get File Extract
+     * Post File Extract
      * @param fileId
      * @param extractorName
      * @param requestBody
      * @returns any Successful Response
      * @throws ApiError
      */
-    public static getFileExtractApiV2FilesFileIdExtractPost(
+    public static postFileExtractApiV2FilesFileIdExtractPost(
         fileId: string,
         extractorName: string,
         requestBody?: any,


### PR DESCRIPTION
One of the methods was using hardcoded rabbitmq credentials and URL.

Renamed docker service to traefik to be more explicit.

Renade route to post from get.