### PR TITLE
Moving createFileMetadata so that it's called after a file update is successful

### DIFF
--- a/frontend/src/components/files/UpdateFile.tsx
+++ b/frontend/src/components/files/UpdateFile.tsx
@@ -27,6 +27,7 @@ export const UpdateFile: React.FC<UpdateFileProps> = (props: UpdateFileProps) =>
 	const listFileMetadata = async (fileId: string | undefined) => dispatch(fetchFileMetadata(fileId));
 	const createFileMetadata = (fileId: string|undefined, metadata:MetadataIn) => dispatch(postFileMetadata(fileId, metadata));
 	const fileMetadataList = useSelector((state: RootState) => state.metadata.fileMetadataList);
+	const files = useSelector((state: RootState) => state.dataset.files);
 
 	const {fileId, setOpen,} = props;
 
@@ -40,8 +41,14 @@ export const UpdateFile: React.FC<UpdateFileProps> = (props: UpdateFileProps) =>
 		setLoading(true);
 		await updateFile(formData, fileId);
 
+		setLoading(false);
+		setOpen(false);
+		listFileVersions(fileId);
+	};
+
+	useEffect(() => {
 		// Update metadata entry for new version of file in db
-		fileMetadataList.forEach((item, idx) => {
+		fileMetadataList.forEach((item) => {
 			if (item.definition !== null) {
 				const metadata: MetadataIn = {
 					context: item.context,
@@ -54,11 +61,7 @@ export const UpdateFile: React.FC<UpdateFileProps> = (props: UpdateFileProps) =>
 				createFileMetadata(fileId, metadata);
 			}
 		});
-
-		setLoading(false);
-		setOpen(false);
-		listFileVersions(fileId);
-	};
+	}, [files]);
 
 	// TODO
 	// @ts-ignore


### PR DESCRIPTION
Steps to reproduce

1. Try to upload a file
2. Try to update that file with another file with different name or content type

Expected behavior - It should show correct error message. 
<img width="1676" alt="Screenshot 2023-07-27 at 10 59 42 AM" src="https://github.com/clowder-framework/clowder2/assets/22405928/8dd541e9-c207-4fe7-b8df-bfe79f989c32">
