### PR TITLE
fix dataset submit after metadata

### DIFF
--- a/frontend/src/components/datasets/CreateDataset.tsx
+++ b/frontend/src/components/datasets/CreateDataset.tsx
@@ -94,7 +94,7 @@ export const CreateDataset = (): JSX.Element => {
 			return { ...prevState, [metadata.definition]: metadata };
 		});
 
-		metadataDefinitionList.every((val, idx) => {
+		metadataDefinitionList.map((val, idx) => {
 			if (val.fields[0].required) {
 				// Condition checks whether the current updated field is a required one
 				if (

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -42,7 +42,7 @@ export const UploadFile:React.FC<UploadFileProps> = (props: UploadFileProps) => 
 	const [allowSubmit, setAllowSubmit] = React.useState<boolean>(false);
 
 	const history = useNavigate();
-    
+
 	const checkIfFieldsAreRequired = () => {
 		let required = false;
 
@@ -80,7 +80,7 @@ export const UploadFile:React.FC<UploadFileProps> = (props: UploadFileProps) => 
 			return ({...prevState, [metadata.definition]: metadata});
 		});
 
-		metadataDefinitionList.every((val, idx) => {
+		metadataDefinitionList.map((val, idx) => {
 			if (val.fields[0].required) {
 				// Condition checks whether the current updated field is a required one
 				if (val.name == metadata.definition || val.name in metadataRequestForms) {


### PR DESCRIPTION
Before you could not submit even after you put in values for required metadata.
The problem was using .every instead of .map. With .map finish button is active once all fields are filled out. 