### PR TITLE
fix blank visualization

### DIFF
--- a/frontend/src/components/visualizations/Visualization.tsx
+++ b/frontend/src/components/visualizations/Visualization.tsx
@@ -98,7 +98,7 @@ export const Visualization = (props: previewProps) => {
 											visComponentDefinition.mimeTypes.includes(
 												fileSummary.content_type.content_type
 											)) ||
-											(fileSummary.content_type.main_type !== undefined &&
+											(fileSummary.content_type.content_type === undefined) && (fileSummary.content_type.main_type !== undefined &&
 												fileSummary.content_type.main_type ===
 													visComponentDefinition.mainType))
 									) {


### PR DESCRIPTION
I am not sure if this is a 'proper' fix, will need to check with more visualizations.

The blank visualization was for the geospatial previewer. Even though the jpeg image does not match the content type, the type 'image' matches the main type. 

I changed this so we only match from the main type if there was no content type. 

This seems to work for the image and geospatial things, but I wasn't sure if this might unintentionally cause other previews to not work. So even though this is a small fix and it does fix the problem, I'm not sure if it's right. 