### PR TITLE
Edit Group Name no longer erases group description

### DIFF
--- a/frontend/src/components/groups/EditMenu.tsx
+++ b/frontend/src/components/groups/EditMenu.tsx
@@ -58,6 +58,7 @@ export const EditMenu = (props: ActionsMenuProps): JSX.Element => {
 					setEditNameModalOpen(false);
 				}}
 				groupName={groupAbout.name}
+				groupDescription={groupAbout.description}
 				groupId={groupAbout.id}
 			/>
 			<EditDescriptionModal

--- a/frontend/src/components/groups/EditNameModal.tsx
+++ b/frontend/src/components/groups/EditNameModal.tsx
@@ -23,7 +23,7 @@ type EditNameModalProps = {
 	handleClose: any;
 	groupOwner: string;
 	groupName: string;
-	groupDescription: string;
+	groupDescription: string | undefined;
 	groupId: string | undefined;
 };
 

--- a/frontend/src/components/groups/EditNameModal.tsx
+++ b/frontend/src/components/groups/EditNameModal.tsx
@@ -23,12 +23,13 @@ type EditNameModalProps = {
 	handleClose: any;
 	groupOwner: string;
 	groupName: string;
+	groupDescription: string;
 	groupId: string | undefined;
 };
 
 
 export default function EditNameModal(props: EditNameModalProps) {
-	const {open, handleClose, groupOwner, groupName, groupId} = props;
+	const {open, handleClose, groupOwner, groupName, groupDescription, groupId} = props;
 	const dispatch = useDispatch();
 	const editGroup = (groupId: string | undefined, formData: GroupIn) => dispatch(updateGroup(groupId, formData));
 
@@ -51,7 +52,7 @@ export default function EditNameModal(props: EditNameModalProps) {
 
 	const onSave = async () => {
 		setLoading(true);
-		editGroup(groupId, {"name": name, "users": groupAbout.users});
+		editGroup(groupId, {"name": name, "users": groupAbout.users, "description": groupDescription});
 		setName("");
 		setLoading(false);
 		handleDialogClose();


### PR DESCRIPTION
When editing the name now the group Description stays the same. The group description was not being sent to that modal and was not sent as formData to the backend. Now it is. 