### PR TITLE
add increment flag to download endpoint

### DIFF
--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -259,6 +259,7 @@ async def update_file(
 async def download_file(
     file_id: str,
     version: Optional[int] = None,
+    increment: Optional[bool] = True,
     fs: Minio = Depends(dependencies.get_fs),
     allow: bool = Depends(FileAuthorization("viewer")),
 ):
@@ -287,8 +288,9 @@ async def download_file(
         # Get content type & open file stream
         response = StreamingResponse(content.stream(settings.MINIO_UPLOAD_CHUNK_SIZE))
         response.headers["Content-Disposition"] = "attachment; filename=%s" % file.name
-        # Increment download count
-        await file.update(Inc({FileDB.downloads: 1}))
+        if increment:
+            # Increment download count
+            await file.update(Inc({FileDB.downloads: 1}))
         return response
     else:
         raise HTTPException(status_code=404, detail=f"File {file_id} not found")

--- a/frontend/src/openapi/v2/services/FilesService.ts
+++ b/frontend/src/openapi/v2/services/FilesService.ts
@@ -13,18 +13,21 @@ export class FilesService {
      * Download File
      * @param fileId
      * @param version
+     * @param increment
      * @returns any Successful Response
      * @throws ApiError
      */
     public static downloadFileApiV2FilesFileIdGet(
         fileId: string,
         version?: number,
+        increment: boolean = true,
     ): CancelablePromise<any> {
         return __request({
             method: 'GET',
             path: `/api/v2/files/${fileId}`,
             query: {
                 'version': version,
+                'increment': increment,
             },
             errors: {
                 422: `Validation Error`,

--- a/frontend/src/utils/visualization.js
+++ b/frontend/src/utils/visualization.js
@@ -45,8 +45,8 @@ export async function generateVisDataDownloadUrl(visualizationId) {
 }
 
 export async function generateFileDownloadUrl(fileId, fileVersionNum = 0) {
-	let url = `${config.hostname}/api/v2/files/${fileId}`;
-	if (fileVersionNum > 0) url = url + "?version=" + fileVersionNum;
+	let url = `${config.hostname}/api/v2/files/${fileId}?increment=false`;
+	if (fileVersionNum > 0) url = `${url}&version=${fileVersionNum}`;
 
 	const response = await fetch(url, {
 		method: "GET",


### PR DESCRIPTION
This adds a flag for frontend to use on file download endpoint that disables incrementing of download count, so refreshing page wont increase # of downloads if the visualization downloads the bytes for any reason.