### PR TITLE
adding file size threshold limit on client side

### DIFF
--- a/frontend/src/app.config.ts
+++ b/frontend/src/app.config.ts
@@ -15,6 +15,7 @@ interface Config {
 	extractorInterval: number;
 	eventListenerJobStatus: EventListenerJobStatus;
 	streamingBytes: number;
+	rawDataVisualizationThreshold: number;
 }
 
 const config: Config = <Config>{};
@@ -58,5 +59,6 @@ config["eventListenerJobStatus"]["skipped"] = "SKIPPED";
 config["eventListenerJobStatus"]["resubmitted"] = "RESUBMITTED";
 
 config["streamingBytes"] = 1024 * 10; // 10 MB?
+config["rawDataVisualizationThreshold"] = 1024 * 1024 * 10; // 10 MB
 
 export default config;

--- a/frontend/src/components/visualizations/Visualization.tsx
+++ b/frontend/src/components/visualizations/Visualization.tsx
@@ -9,6 +9,7 @@ import { Grid } from "@mui/material";
 import { VisualizationCard } from "./VisualizationCard";
 import { VisualizationRawBytesCard } from "./VisualizationRawBytesCard";
 import { VisualizationSpecCard } from "./VisualizationSpecCard";
+import config from "../../app.config";
 
 type previewProps = {
 	fileId?: string;
@@ -94,10 +95,14 @@ export const Visualization = (props: previewProps) => {
 								// if no visualization config exist, guess which widget to use by looking at the mime type of
 								// the raw bytes
 								else {
+									//check if file size is greater than threshold, if it is, then show no visualization
+									if (fileSummary && fileSummary.bytes && fileSummary.bytes >= config["rawDataVisualizationThreshold"]) {
+										console.log("File is greater than threshold");
+									}
 									// try match mime type first
 									// then fallback to match main type
 									// to instantiate components correspondingly
-									if (
+									else if (
 										fileSummary &&
 										fileSummary.content_type !== undefined &&
 										((fileSummary.content_type.content_type !== undefined &&


### PR DESCRIPTION
Initial implementation : I have put the logic on client side to check for file threshold for visualization.

I am now looking into ways to put the entire logic in backend.


To test: 
1. Upload a file greater than threshold size
2. It should not show the file in visualization tab and show a console log.