### PR TITLE
`submit_file_job` takes 5 parameters, put we had 6. 

### DIFF
--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -373,7 +373,6 @@ async def post_file_extract(
             parameters,
             user,
             rabbitmq_client,
-            access_token,
         )
     else:
         raise HTTPException(status_code=404, detail=f"File {file_id} not found")


### PR DESCRIPTION
The extra parameter `access_token` was throwing an error when submitting a file for extraction.