### PR TITLE
685 retire the function that generate frontend url for visualization

### DIFF
--- a/frontend/src/actions/dataset.js
+++ b/frontend/src/actions/dataset.js
@@ -1,11 +1,10 @@
 import { V2 } from "../openapi";
 import {
 	handleErrors,
-	handleErrorsAuthorization, handleErrorsInline,
+	handleErrorsAuthorization,
+	handleErrorsInline,
 	resetFailedReason,
 } from "./common";
-import config from "../app.config";
-import { getHeader } from "../utils/common";
 
 export const SET_DATASET_GROUP_ROLE = "SET_DATASET_GROUP_ROLE";
 
@@ -50,7 +49,10 @@ export function setDatasetUserRole(datasetId, username, roleType) {
 			})
 			.catch((reason) => {
 				dispatch(
-					handleErrorsInline(reason, setDatasetUserRole(datasetId, username, roleType))
+					handleErrorsInline(
+						reason,
+						setDatasetUserRole(datasetId, username, roleType)
+					)
 				);
 			});
 	};
@@ -358,44 +360,5 @@ export function fetchDatasetRoles(datasetId) {
 					handleErrorsAuthorization(reason, fetchDatasetRoles(datasetId))
 				);
 			});
-	};
-}
-
-export const DOWNLOAD_DATASET = "DOWNLOAD_DATASET";
-
-export function datasetDownloaded(datasetId, filename = "") {
-	return async (dispatch) => {
-		if (filename !== "") {
-			filename = filename.replace(/\s+/g, "_");
-			filename = `${filename}.zip`;
-		} else {
-			filename = `${datasetId}.zip`;
-		}
-		const endpoint = `${config.hostname}/api/v2/datasets/${datasetId}/download`;
-		const response = await fetch(endpoint, {
-			method: "GET",
-			mode: "cors",
-			headers: await getHeader(),
-		});
-
-		if (response.status === 200) {
-			const blob = await response.blob();
-			if (window.navigator.msSaveOrOpenBlob) {
-				window.navigator.msSaveBlob(blob, filename);
-			} else {
-				const anchor = window.document.createElement("a");
-				anchor.href = window.URL.createObjectURL(blob);
-				anchor.download = filename;
-				document.body.appendChild(anchor);
-				anchor.click();
-				document.body.removeChild(anchor);
-			}
-			dispatch({
-				type: DOWNLOAD_DATASET,
-				receivedAt: Date.now(),
-			});
-		} else {
-			dispatch(handleErrors(response, datasetDownloaded(datasetId, filename)));
-		}
 	};
 }

--- a/frontend/src/components/Explore.tsx
+++ b/frontend/src/components/Explore.tsx
@@ -4,7 +4,6 @@ import { Box, Button, ButtonGroup, Grid, Tab, Tabs } from "@mui/material";
 import { RootState } from "../types/data";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchDatasets } from "../actions/dataset";
-import { downloadThumbnail } from "../utils/visualization";
 
 import { a11yProps, TabPanel } from "./tabs/TabComponent";
 import DatasetCard from "./datasets/DatasetCard";
@@ -30,7 +29,6 @@ export const Explore = (): JSX.Element => {
 	) => dispatch(fetchDatasets(skip, limit, mine));
 	const datasets = useSelector((state: RootState) => state.dataset.datasets);
 
-	const [datasetThumbnailList, setDatasetThumbnailList] = useState<any>([]);
 	// TODO add option to determine limit number; default show 5 datasets each time
 	const [currPageNum, setCurrPageNum] = useState<number>(0);
 	const [limit] = useState<number>(20);
@@ -49,31 +47,6 @@ export const Explore = (): JSX.Element => {
 
 	// fetch thumbnails from each individual dataset/id calls
 	useEffect(() => {
-		(async () => {
-			if (datasets !== undefined && datasets.length > 0) {
-				// TODO change the type any to something else
-				const datasetThumbnailListTemp: any = [];
-				await Promise.all(
-					datasets.map(async (dataset) => {
-						// add thumbnails
-						if (
-							dataset["thumbnail"] !== null &&
-							dataset["thumbnail"] !== undefined
-						) {
-							const thumbnailURL = await downloadThumbnail(
-								dataset["thumbnail"]
-							);
-							datasetThumbnailListTemp.push({
-								id: dataset["id"],
-								thumbnail: thumbnailURL,
-							});
-						}
-					})
-				);
-				setDatasetThumbnailList(datasetThumbnailListTemp);
-			}
-		})();
-
 		// disable flipping if reaches the last page
 		if (datasets.length < limit) setNextDisabled(true);
 		else setNextDisabled(false);
@@ -128,8 +101,7 @@ export const Explore = (): JSX.Element => {
 							</Box>
 							<TabPanel value={selectedTabIndex} index={0}>
 								<Grid container spacing={2}>
-									{datasets !== undefined &&
-									datasetThumbnailList !== undefined ? (
+									{datasets !== undefined ? (
 										datasets.map((dataset) => {
 											return (
 												<Grid

--- a/frontend/src/components/datasets/DatasetCard.tsx
+++ b/frontend/src/components/datasets/DatasetCard.tsx
@@ -13,17 +13,17 @@ import {
 	Tooltip,
 } from "@mui/material";
 import { Download } from "@mui/icons-material";
-import { generateVisDataDownloadUrl } from "../../utils/visualization";
+import { generateThumbnailUrl } from "../../utils/visualization";
 import config from "../../app.config";
 // import {Favorite, Share} from "@material-ui/icons";
 
 type DatasetCardProps = {
-	id: string;
-	name: string;
-	author: string;
-	created: string | Date;
-	description: string;
-	thumbnail_id?: string;
+	id?: string;
+	name?: string;
+	author?: string;
+	created?: string | Date;
+	description?: string;
+	thumbnailId?: string;
 };
 
 export default function DatasetCard(props: DatasetCardProps) {
@@ -31,19 +31,11 @@ export default function DatasetCard(props: DatasetCardProps) {
 	const [thumbnailUrl, setThumbnailUrl] = useState("");
 
 	useEffect(() => {
-		const fetchThumbnailUrl = async () => {
-			try {
-				let url = "";
-				if (thumbnailId) {
-					url = await generateVisDataDownloadUrl(thumbnailId);
-				}
-				setThumbnailUrl(url);
-			} catch (error) {
-				console.error("Error fetching data:", error);
-			}
-		};
-
-		fetchThumbnailUrl();
+		let url = "";
+		if (thumbnailId) {
+			url = generateThumbnailUrl(thumbnailId);
+		}
+		setThumbnailUrl(url);
 	}, [thumbnailId]);
 
 	const formattedCreated = parseDate(created);

--- a/frontend/src/components/files/FilesTableFileEntry.tsx
+++ b/frontend/src/components/files/FilesTableFileEntry.tsx
@@ -9,7 +9,7 @@ import { parseDate } from "../../utils/common";
 import FileMenu from "./FileMenu";
 import prettyBytes from "pretty-bytes";
 import { FileOut } from "../../openapi/v2";
-import { downloadThumbnail } from "../../utils/visualization";
+import { generateThumbnailUrl } from "../../utils/visualization";
 
 type FilesTableFileEntryProps = {
 	iconStyle: {};
@@ -23,19 +23,11 @@ export function FilesTableFileEntry(props: FilesTableFileEntryProps) {
 	const [thumbnailUrl, setThumbnailUrl] = useState("");
 
 	useEffect(() => {
-		const fetchThumbnailUrl = async () => {
-			try {
-				let url = "";
-				if (file.thumbnail_id) {
-					url = await downloadThumbnail(file.thumbnail_id);
-				}
-				setThumbnailUrl(url);
-			} catch (error) {
-				console.error("Error fetching data:", error);
-			}
-		};
-
-		fetchThumbnailUrl();
+		let url = "";
+		if (file.thumbnail_id) {
+			url = generateThumbnailUrl(file.thumbnail_id);
+		}
+		setThumbnailUrl(url);
 	}, [file]);
 
 	return (
@@ -60,10 +52,11 @@ export function FilesTableFileEntry(props: FilesTableFileEntryProps) {
 						<Button onClick={() => selectFile(file.id)}>{file.name}</Button>
 					</TableCell>
 					<TableCell>
-						<VersionChip selectedVersion={file.version_num}
-									 setSelectedVersion={null}
-									 versionNumbers={null}
-									 isClickable={false}
+						<VersionChip
+							selectedVersion={file.version_num}
+							setSelectedVersion={null}
+							versionNumbers={null}
+							isClickable={false}
 						/>
 					</TableCell>
 					<TableCell align="right">

--- a/frontend/src/components/listeners/Listeners.tsx
+++ b/frontend/src/components/listeners/Listeners.tsx
@@ -30,8 +30,8 @@ import SubmitExtraction from "./SubmitExtraction";
 import { capitalize } from "../../utils/common";
 
 type ListenerProps = {
-	fileId: string;
-	datasetId: string;
+	fileId?: string;
+	datasetId?: string;
 };
 
 export function Listeners(props: ListenerProps) {

--- a/frontend/src/components/visualizations/Audio/Audio.tsx
+++ b/frontend/src/components/visualizations/Audio/Audio.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
 import {
 	generateFileDownloadUrl,
 	generateVisDataDownloadUrl,
@@ -13,26 +12,16 @@ type AudioProps = {
 export default function Audio(props: AudioProps) {
 	const { fileId, visualizationId } = props;
 
-	const dispatch = useDispatch();
-
 	const [url, setUrl] = useState("");
 
 	useEffect(() => {
-		const fetchUrl = async () => {
-			try {
-				let downloadUrl;
-				if (visualizationId) {
-					downloadUrl = await generateVisDataDownloadUrl(visualizationId);
-				} else {
-					downloadUrl = await generateFileDownloadUrl(fileId, 0);
-				}
-				setUrl(downloadUrl);
-			} catch (error) {
-				console.error("Error fetching data:", error);
-			}
-		};
-
-		fetchUrl();
+		let downloadUrl;
+		if (visualizationId) {
+			downloadUrl = generateVisDataDownloadUrl(visualizationId);
+		} else {
+			downloadUrl = generateFileDownloadUrl(fileId, 0);
+		}
+		setUrl(downloadUrl);
 	}, [visualizationId, fileId]);
 
 	return (() => {

--- a/frontend/src/components/visualizations/Iframe/Iframe.tsx
+++ b/frontend/src/components/visualizations/Iframe/Iframe.tsx
@@ -15,21 +15,13 @@ export default function string(props: IframeProps) {
 	const [url, setUrl] = useState("");
 
 	useEffect(() => {
-		const fetchUrl = async () => {
-			try {
-				let downloadUrl;
-				if (visualizationId) {
-					downloadUrl = await generateVisDataDownloadUrl(visualizationId);
-				} else {
-					downloadUrl = await generateFileDownloadUrl(fileId, 0);
-				}
-				setUrl(downloadUrl);
-			} catch (error) {
-				console.error("Error fetching data:", error);
-			}
-		};
-
-		fetchUrl();
+		let downloadUrl;
+		if (visualizationId) {
+			downloadUrl = generateVisDataDownloadUrl(visualizationId);
+		} else {
+			downloadUrl = generateFileDownloadUrl(fileId, 0);
+		}
+		setUrl(downloadUrl);
 	}, [visualizationId, fileId]);
 
 	return (() => {

--- a/frontend/src/components/visualizations/Image/Image.tsx
+++ b/frontend/src/components/visualizations/Image/Image.tsx
@@ -15,21 +15,13 @@ export default function Image(props: ImageProps) {
 	const [url, setUrl] = useState("");
 
 	useEffect(() => {
-		const fetchUrl = async () => {
-			try {
-				let downloadUrl;
-				if (visualizationId) {
-					downloadUrl = await generateVisDataDownloadUrl(visualizationId);
-				} else {
-					downloadUrl = await generateFileDownloadUrl(fileId, 0);
-				}
-				setUrl(downloadUrl);
-			} catch (error) {
-				console.error("Error fetching data:", error);
-			}
-		};
-
-		fetchUrl();
+		let downloadUrl;
+		if (visualizationId) {
+			downloadUrl = generateVisDataDownloadUrl(visualizationId);
+		} else {
+			downloadUrl = generateFileDownloadUrl(fileId, 0);
+		}
+		setUrl(downloadUrl);
 	}, [visualizationId, fileId]);
 
 	return (() => {

--- a/frontend/src/components/visualizations/Video/Video.tsx
+++ b/frontend/src/components/visualizations/Video/Video.tsx
@@ -15,21 +15,13 @@ export default function Video(props: VideoProps) {
 	const [url, setUrl] = useState("");
 
 	useEffect(() => {
-		const fetchUrl = async () => {
-			try {
-				let downloadUrl;
-				if (visualizationId) {
-					downloadUrl = await generateVisDataDownloadUrl(visualizationId);
-				} else {
-					downloadUrl = await generateFileDownloadUrl(fileId, 0);
-				}
-				setUrl(downloadUrl);
-			} catch (error) {
-				console.error("Error fetching data:", error);
-			}
-		};
-
-		fetchUrl();
+		let downloadUrl;
+		if (visualizationId) {
+			downloadUrl = generateVisDataDownloadUrl(visualizationId);
+		} else {
+			downloadUrl = generateFileDownloadUrl(fileId, 0);
+		}
+		setUrl(downloadUrl);
 	}, [visualizationId, fileId]);
 
 	return (() => {

--- a/frontend/src/components/visualizations/Video/manifest.json
+++ b/frontend/src/components/visualizations/Video/manifest.json
@@ -12,7 +12,8 @@
 		"name": "Video",
 		"mainType": "video",
 		"mimeTypes": [
-			"video/*"
+			"video/mp4",
+			"video/ogg"
 		],
 		"props": {
 			"fileId": "string"

--- a/frontend/src/reducers/dataset.ts
+++ b/frontend/src/reducers/dataset.ts
@@ -20,9 +20,10 @@ import {
 } from "../actions/file";
 import { RECEIVE_DATASET_ROLE } from "../actions/authorization";
 import { DataAction } from "../types/action";
-import { Dataset, DatasetState } from "../types/data";
+import { DatasetState } from "../types/data";
 import {
 	AuthorizationBase,
+	DatasetOut as Dataset,
 	DatasetRoles,
 	FileOut as File,
 	UserOut,

--- a/frontend/src/reducers/dataset.ts
+++ b/frontend/src/reducers/dataset.ts
@@ -92,9 +92,6 @@ const dataset = (state = defaultState, action: DataAction) => {
 					(dataset) => dataset.id !== action.dataset.id
 				),
 			});
-		// case DOWNLOAD_DATASET:
-		// 	// TODO do nothing for now; but in the future can utilize to display certain effects
-		// 	return Object.assign({}, state, {});
 		default:
 			return state;
 	}

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -1,5 +1,6 @@
 import {
 	AuthorizationBase,
+	DatasetOut as Dataset,
 	DatasetRoles,
 	EventListenerJobDB,
 	FileOut as FileSummary,
@@ -14,20 +15,6 @@ import {
 	VisualizationConfigOut,
 	VisualizationDataOut,
 } from "../openapi/v2";
-
-export interface Dataset {
-	name: string;
-	description: string;
-	_id: string;
-	creator: UserOut;
-	created: string | Date;
-	modified: string | Date;
-	files: string[];
-	status: string;
-	views: string;
-	downloads: string;
-	thumbnail: string;
-}
 
 export interface Extractor {
 	name: string;

--- a/frontend/src/utils/visualization.js
+++ b/frontend/src/utils/visualization.js
@@ -1,7 +1,7 @@
 import { getHeader } from "./common";
 import config from "../app.config";
 
-export function downloadThumbnail(thumbnailId) {
+export function generateThumbnailUrl(thumbnailId) {
 	return `${config.hostname}/api/v2/thumbnails/${thumbnailId}`;
 }
 

--- a/frontend/src/utils/visualization.js
+++ b/frontend/src/utils/visualization.js
@@ -1,31 +1,8 @@
 import { getHeader } from "./common";
 import config from "../app.config";
 
-export async function downloadThumbnail(thumbnailId, title = null) {
-	const url = `${config.hostname}/api/v2/thumbnails/${thumbnailId}`;
-
-	const authHeader = getHeader();
-	const response = await fetch(url, {
-		method: "GET",
-		mode: "cors",
-		headers: authHeader,
-	});
-	if (response.status === 200) {
-		const blob = await response.blob();
-		if (window.navigator.msSaveOrOpenBlob) {
-			window.navigator.msSaveBlob(blob, thumbnailId);
-			return null;
-		} else {
-			return window.URL.createObjectURL(blob);
-		}
-	} else if (response.status === 401) {
-		// TODO handle error
-		// logout();
-		return null;
-	} else {
-		// TODO handle error
-		return null;
-	}
+export function downloadThumbnail(thumbnailId) {
+	return `${config.hostname}/api/v2/thumbnails/${thumbnailId}`;
 }
 
 export function generateVisDataDownloadUrl(visualizationId) {

--- a/frontend/src/utils/visualization.js
+++ b/frontend/src/utils/visualization.js
@@ -28,38 +28,15 @@ export async function downloadThumbnail(thumbnailId, title = null) {
 	}
 }
 
-export async function generateVisDataDownloadUrl(visualizationId) {
-	const endpoint = `${config.hostname}/api/v2/visualizations/${visualizationId}/bytes`;
-	const response = await fetch(endpoint, {
-		method: "GET",
-		mode: "cors",
-		headers: await getHeader(),
-	});
-
-	if (response.status === 200) {
-		const blob = await response.blob();
-		return window.URL.createObjectURL(blob);
-	} else {
-		return "";
-	}
+export function generateVisDataDownloadUrl(visualizationId) {
+	return `${config.hostname}/api/v2/visualizations/${visualizationId}/bytes`;
 }
 
-export async function generateFileDownloadUrl(fileId, fileVersionNum = 0) {
+export function generateFileDownloadUrl(fileId, fileVersionNum = 0) {
 	let url = `${config.hostname}/api/v2/files/${fileId}?increment=false`;
 	if (fileVersionNum > 0) url = `${url}&version=${fileVersionNum}`;
 
-	const response = await fetch(url, {
-		method: "GET",
-		mode: "cors",
-		headers: await getHeader(),
-	});
-
-	if (response.status === 200) {
-		const blob = await response.blob();
-		return window.URL.createObjectURL(blob);
-	} else {
-		return "";
-	}
+	return url;
 }
 
 export async function downloadVisData(visualizationId) {


### PR DESCRIPTION
Update all the "download url" related method and usage to directly use the /api endpoint since now cookie auth is supported

Things to test:
1. Dataset Thumbnail
2. File thumbnail
3. Image vis
4. Video vis
5. Audio vis
6. Iframe