### PR TITLE
712 redesign the order of file upload form

### DIFF
--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -12,7 +12,7 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../types/data";
 
-import { UploadFileModal } from "./UploadFileModal";
+import { UploadFileInput } from "./UploadFileInput";
 import { CreateMetadata } from "../metadata/CreateMetadata";
 import {
 	fetchMetadataDefinitions,
@@ -131,7 +131,6 @@ export const UploadFile: React.FC<UploadFileProps> = (
 
 	// finish button post dataset; dataset ID triggers metadata posting
 	const handleFinish = () => {
-		// check file
 		// Triggers spinner
 		setLoading(true);
 
@@ -169,7 +168,7 @@ export const UploadFile: React.FC<UploadFileProps> = (
 					{/*step 1 Metadata*/}
 					<Step key="fill-in-metadata">
 						<StepLabel>Fill In Metadata</StepLabel>
-						<StepContent>
+						<StepContent TransitionProps={{ unmountOnExit: false }}>
 							<Typography>Provide us the metadata about your file.</Typography>
 							<Box>
 								<CreateMetadata setMetadata={setMetadata} />
@@ -192,10 +191,10 @@ export const UploadFile: React.FC<UploadFileProps> = (
 					{/* step 2 attach files */}
 					<Step key="attach-files">
 						<StepLabel>Attach Files</StepLabel>
-						<StepContent>
+						<StepContent TransitionProps={{ unmountOnExit: false }}>
 							<Typography>Upload files to the dataset.</Typography>
 							<Box>
-								<UploadFileModal setSelectedFile={setSelectedFile} />
+								<UploadFileInput setSelectedFile={setSelectedFile} />
 								<Box className="inputGroup">
 									<Button
 										variant="contained"

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -88,17 +88,12 @@ export const UploadFile: React.FC<UploadFileProps> = (
 
 	const checkIfFieldsAreFilled = () => {
 		return metadataDefinitionList.every((val) => {
-			if (val.fields[0].required) {
-				return val.fields.every((field) => {
-					return (
-						metadataRequestForms[val.name] &&
-						metadataRequestForms[val.name].content[field.name] !== ""
-					);
-				});
-			} else {
-				// Non-required fields are considered as filled
-				return true;
-			}
+			return val.fields.every((field) => {
+				return field.required
+					? metadataRequestForms[val.name] &&
+							metadataRequestForms[val.name].content[field.name] !== ""
+					: true;
+			});
 		});
 	};
 

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -85,20 +85,8 @@ export const UploadFile: React.FC<UploadFileProps> = (
 
 		return required;
 	};
+
 	// step 1
-	const onFileSave = (selectedFile: File) => {
-		setSelectedFile(selectedFile);
-
-		// If no metadata fields are marked as required, allow user to skip directly to submit
-		if (checkIfFieldsAreRequired()) {
-			setAllowSubmit(false);
-		} else {
-			setAllowSubmit(true);
-		}
-
-		handleNext();
-	};
-	// step 2
 	const setMetadata = (metadata: any) => {
 		// TODO wrap this in to a function
 		setMetadataRequestForms((prevState) => {
@@ -130,6 +118,12 @@ export const UploadFile: React.FC<UploadFileProps> = (
 	// step
 	const [activeStep, setActiveStep] = useState(0);
 	const handleNext = () => {
+		// If no metadata fields are marked as required, allow user to skip directly to submit
+		if (checkIfFieldsAreRequired()) {
+			setAllowSubmit(false);
+		} else {
+			setAllowSubmit(true);
+		}
 		setActiveStep((prevActiveStep) => prevActiveStep + 1);
 	};
 	const handleBack = () => {
@@ -172,22 +166,11 @@ export const UploadFile: React.FC<UploadFileProps> = (
 		<LoadingOverlay active={loading} spinner text="Uploading file...">
 			<Box sx={{ padding: "5%" }}>
 				<Stepper activeStep={activeStep} orientation="vertical">
-					{/* step 1 attach files */}
-					<Step key="attach-files">
-						<StepLabel>Attach Files</StepLabel>
-						<StepContent>
-							<Typography>Upload files to the dataset.</Typography>
-							<Box>
-								<UploadFileModal onSave={onFileSave} />
-							</Box>
-						</StepContent>
-					</Step>
-
-					{/*step 2 Metadata*/}
+					{/*step 1 Metadata*/}
 					<Step key="fill-in-metadata">
 						<StepLabel>Fill In Metadata</StepLabel>
 						<StepContent>
-							<Typography>Provide us your metadata about file.</Typography>
+							<Typography>Provide us the metadata about your file.</Typography>
 							<Box>
 								<CreateMetadata setMetadata={setMetadata} />
 							</Box>
@@ -196,16 +179,35 @@ export const UploadFile: React.FC<UploadFileProps> = (
 								<>
 									<Button
 										variant="contained"
-										onClick={handleFinish}
+										onClick={handleNext}
 										disabled={!allowSubmit}
 										sx={{ mt: 1, mr: 1 }}
+									>
+										Next
+									</Button>
+								</>
+							</Box>
+						</StepContent>
+					</Step>
+					{/* step 2 attach files */}
+					<Step key="attach-files">
+						<StepLabel>Attach Files</StepLabel>
+						<StepContent>
+							<Typography>Upload files to the dataset.</Typography>
+							<Box>
+								<UploadFileModal setSelectedFile={setSelectedFile} />
+								<Box className="inputGroup">
+									<Button
+										variant="contained"
+										onClick={handleFinish}
+										disabled={!selectedFile}
 									>
 										Finish
 									</Button>
 									<Button onClick={handleBack} sx={{ mt: 1, mr: 1 }}>
 										Back
 									</Button>
-								</>
+								</Box>
 							</Box>
 						</StepContent>
 					</Step>

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -70,7 +70,7 @@ export const UploadFile: React.FC<UploadFileProps> = (
 
 	const [selectedFile, setSelectedFile] = useState<File | null>(null);
 	const [metadataRequestForms, setMetadataRequestForms] = useState({});
-	const [allowSubmit, setAllowSubmit] = React.useState<boolean>(false);
+	const [allFilled, setAllFilled] = React.useState<boolean>(false);
 
 	const history = useNavigate();
 
@@ -116,8 +116,19 @@ export const UploadFile: React.FC<UploadFileProps> = (
 			}
 			return { ...prevState, [metadata.definition]: metadata };
 		});
-		setAllowSubmit(checkIfFieldsAreFilled(metadata));
 	};
+
+	useEffect(() => {
+		if (Object.keys(metadataRequestForms).length > 0) {
+			setAllFilled(
+				Object.keys(metadataRequestForms).every((key) => {
+					return checkIfFieldsAreFilled(metadataRequestForms[key]);
+				})
+			);
+		} else {
+			setAllFilled(false);
+		}
+	}, [metadataRequestForms]);
 
 	// step
 	const [activeStep, setActiveStep] = useState(0);
@@ -125,8 +136,8 @@ export const UploadFile: React.FC<UploadFileProps> = (
 		setActiveStep((prevActiveStep) => prevActiveStep + 1);
 	};
 	const handleBack = () => {
-		// since return from previous step which already filled the required fields, always allow submit
-		setAllowSubmit(true);
+		// since return from previous step which already filled the required fields
+		setAllFilled(true);
 		setActiveStep((prevActiveStep) => prevActiveStep - 1);
 	};
 
@@ -180,7 +191,7 @@ export const UploadFile: React.FC<UploadFileProps> = (
 									<Button
 										variant="contained"
 										onClick={handleNext}
-										disabled={!(!checkIfFieldsAreRequired() || allowSubmit)}
+										disabled={!checkIfFieldsAreRequired() ? false : !allFilled}
 										sx={{ mt: 1, mr: 1 }}
 									>
 										Next

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -90,7 +90,9 @@ export const UploadFile: React.FC<UploadFileProps> = (
 		return metadataDefinitionList.every((val) => {
 			return val.fields.every((field) => {
 				return field.required
-					? metadataRequestForms[val.name] &&
+					? metadataRequestForms[val.name] !== undefined &&
+							metadataRequestForms[val.name].content[field.name] !==
+								undefined &&
 							metadataRequestForms[val.name].content[field.name] !== ""
 					: true;
 			});

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -77,7 +77,7 @@ export const UploadFile: React.FC<UploadFileProps> = (
 	const checkIfFieldsAreRequired = () => {
 		let required = false;
 
-		metadataDefinitionList.forEach((val, idx) => {
+		metadataDefinitionList.forEach((val, _) => {
 			if (val.fields[0].required) {
 				required = true;
 			}
@@ -118,7 +118,6 @@ export const UploadFile: React.FC<UploadFileProps> = (
 	// step
 	const [activeStep, setActiveStep] = useState(0);
 	const handleNext = () => {
-		// If no metadata fields are marked as required, allow user to skip directly to submit
 		if (checkIfFieldsAreRequired()) {
 			setAllowSubmit(false);
 		} else {
@@ -132,6 +131,7 @@ export const UploadFile: React.FC<UploadFileProps> = (
 
 	// finish button post dataset; dataset ID triggers metadata posting
 	const handleFinish = () => {
+		// check file
 		// Triggers spinner
 		setLoading(true);
 

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import {
 	Box,
 	Button,
+	Grid,
 	Step,
 	StepContent,
 	StepLabel,
@@ -175,18 +176,19 @@ export const UploadFile: React.FC<UploadFileProps> = (
 								<CreateMetadata setMetadata={setMetadata} />
 							</Box>
 							{/*buttons*/}
-							<Box sx={{ mb: 2 }}>
-								<>
+							<Grid container>
+								<Grid xs={11}>
 									<Button
 										variant="contained"
 										onClick={handleNext}
 										disabled={!checkIfFieldsAreRequired() ? false : !allFilled}
-										sx={{ mt: 1, mr: 1 }}
+										sx={{ display: "block", marginLeft: "auto" }}
 									>
 										Next
 									</Button>
-								</>
-							</Box>
+								</Grid>
+								<Grid xs={1}></Grid>
+							</Grid>
 						</StepContent>
 					</Step>
 					{/* step 2 attach files */}
@@ -197,15 +199,16 @@ export const UploadFile: React.FC<UploadFileProps> = (
 							<Box>
 								<UploadFileInput setSelectedFile={setSelectedFile} />
 								<Box className="inputGroup">
+									<Button onClick={handleBack} sx={{ float: "right" }}>
+										Back
+									</Button>
 									<Button
 										variant="contained"
 										onClick={handleFinish}
 										disabled={!selectedFile}
+										sx={{ float: "right" }}
 									>
 										Finish
-									</Button>
-									<Button onClick={handleBack} sx={{ mt: 1, mr: 1 }}>
-										Back
 									</Button>
 								</Box>
 							</Box>

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -86,23 +86,20 @@ export const UploadFile: React.FC<UploadFileProps> = (
 		return required;
 	};
 
-	const checkIfFieldsAreFilled = (metadata: { definition: string }) => {
-		let filled = false;
-
-		metadataDefinitionList.map((val, _) => {
+	const checkIfFieldsAreFilled = () => {
+		return metadataDefinitionList.every((val) => {
 			if (val.fields[0].required) {
-				// Condition checks whether the current updated field is a required one
-				if (
-					val.name == metadata.definition ||
-					val.name in metadataRequestForms
-				) {
-					filled = true;
-				} else {
-					filled = false;
-				}
+				return val.fields.every((field) => {
+					return (
+						metadataRequestForms[val.name] &&
+						metadataRequestForms[val.name].content[field.name] !== ""
+					);
+				});
+			} else {
+				// Non-required fields are considered as filled
+				return true;
 			}
 		});
-		return filled;
 	};
 
 	// step 1
@@ -120,11 +117,7 @@ export const UploadFile: React.FC<UploadFileProps> = (
 
 	useEffect(() => {
 		if (Object.keys(metadataRequestForms).length > 0) {
-			setAllFilled(
-				Object.keys(metadataRequestForms).every((key) => {
-					return checkIfFieldsAreFilled(metadataRequestForms[key]);
-				})
-			);
+			setAllFilled(checkIfFieldsAreFilled(metadataRequestForms));
 		} else {
 			setAllFilled(false);
 		}
@@ -136,8 +129,6 @@ export const UploadFile: React.FC<UploadFileProps> = (
 		setActiveStep((prevActiveStep) => prevActiveStep + 1);
 	};
 	const handleBack = () => {
-		// since return from previous step which already filled the required fields
-		setAllFilled(true);
 		setActiveStep((prevActiveStep) => prevActiveStep - 1);
 	};
 
@@ -177,6 +168,7 @@ export const UploadFile: React.FC<UploadFileProps> = (
 		<LoadingOverlay active={loading} spinner text="Uploading file...">
 			<Box sx={{ padding: "5%" }}>
 				<Stepper activeStep={activeStep} orientation="vertical">
+					{/*<Stepper activeStep={activeStep}>*/}
 					{/*step 1 Metadata*/}
 					<Step key="fill-in-metadata">
 						<StepLabel>Fill In Metadata</StepLabel>

--- a/frontend/src/components/files/UploadFile.tsx
+++ b/frontend/src/components/files/UploadFile.tsx
@@ -86,6 +86,25 @@ export const UploadFile: React.FC<UploadFileProps> = (
 		return required;
 	};
 
+	const checkIfFieldsAreFilled = (metadata: { definition: string }) => {
+		let filled = false;
+
+		metadataDefinitionList.map((val, _) => {
+			if (val.fields[0].required) {
+				// Condition checks whether the current updated field is a required one
+				if (
+					val.name == metadata.definition ||
+					val.name in metadataRequestForms
+				) {
+					filled = true;
+				} else {
+					filled = false;
+				}
+			}
+		});
+		return filled;
+	};
+
 	// step 1
 	const setMetadata = (metadata: any) => {
 		// TODO wrap this in to a function
@@ -97,35 +116,17 @@ export const UploadFile: React.FC<UploadFileProps> = (
 			}
 			return { ...prevState, [metadata.definition]: metadata };
 		});
-
-		metadataDefinitionList.map((val, idx) => {
-			if (val.fields[0].required) {
-				// Condition checks whether the current updated field is a required one
-				if (
-					val.name == metadata.definition ||
-					val.name in metadataRequestForms
-				) {
-					setAllowSubmit(true);
-					return true;
-				} else {
-					setAllowSubmit(false);
-					return false;
-				}
-			}
-		});
+		setAllowSubmit(checkIfFieldsAreFilled(metadata));
 	};
 
 	// step
 	const [activeStep, setActiveStep] = useState(0);
 	const handleNext = () => {
-		if (checkIfFieldsAreRequired()) {
-			setAllowSubmit(false);
-		} else {
-			setAllowSubmit(true);
-		}
 		setActiveStep((prevActiveStep) => prevActiveStep + 1);
 	};
 	const handleBack = () => {
+		// since return from previous step which already filled the required fields, always allow submit
+		setAllowSubmit(true);
 		setActiveStep((prevActiveStep) => prevActiveStep - 1);
 	};
 
@@ -179,7 +180,7 @@ export const UploadFile: React.FC<UploadFileProps> = (
 									<Button
 										variant="contained"
 										onClick={handleNext}
-										disabled={!allowSubmit}
+										disabled={!(!checkIfFieldsAreRequired() || allowSubmit)}
 										sx={{ mt: 1, mr: 1 }}
 									>
 										Next

--- a/frontend/src/components/files/UploadFileInput.tsx
+++ b/frontend/src/components/files/UploadFileInput.tsx
@@ -6,7 +6,7 @@ type UploadFileModalProps = {
 	setSelectedFile: any;
 };
 
-export const UploadFileModal: React.FC<UploadFileModalProps> = (
+export const UploadFileInput: React.FC<UploadFileModalProps> = (
 	props: UploadFileModalProps
 ) => {
 	const { setSelectedFile } = props;

--- a/frontend/src/components/files/UploadFileModal.tsx
+++ b/frontend/src/components/files/UploadFileModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Container, Input } from "@mui/material";
+import { Box, Input } from "@mui/material";
 
 type UploadFileModalProps = {
 	setSelectedFile: any;
@@ -16,13 +16,13 @@ export const UploadFileModal: React.FC<UploadFileModalProps> = (
 	};
 
 	return (
-		<Container sx={{ width: "100%", padding: "1em" }}>
+		<Box sx={{ width: "100%", padding: "1em 0em" }}>
 			<Input
 				id="file-input"
 				type="file"
 				onChange={handleFileChange}
 				sx={{ width: "100%" }}
 			/>
-		</Container>
+		</Box>
 	);
 };

--- a/frontend/src/components/files/UploadFileModal.tsx
+++ b/frontend/src/components/files/UploadFileModal.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 
-import { Box, Button, Container, Input } from "@mui/material";
+import { Container, Input } from "@mui/material";
 
 type UploadFileModalProps = {
-	onSave: any;
+	setSelectedFile: any;
 };
 
 export const UploadFileModal: React.FC<UploadFileModalProps> = (
 	props: UploadFileModalProps
 ) => {
-	const { onSave } = props;
-	const [selectedFile, setSelectedFile] = React.useState<File | null>(null);
+	const { setSelectedFile } = props;
 
 	const handleFileChange = (event) => {
 		setSelectedFile(event.target.files[0]);
@@ -24,17 +23,6 @@ export const UploadFileModal: React.FC<UploadFileModalProps> = (
 				onChange={handleFileChange}
 				sx={{ width: "100%" }}
 			/>
-			<Box className="inputGroup">
-				<Button
-					variant="contained"
-					onClick={() => {
-						onSave(selectedFile);
-					}}
-					disabled={!selectedFile}
-				>
-					Upload
-				</Button>
-			</Box>
 		</Container>
 	);
 };

--- a/frontend/src/components/metadata/CreateMetadata.tsx
+++ b/frontend/src/components/metadata/CreateMetadata.tsx
@@ -1,26 +1,30 @@
-import React, {useEffect} from "react";
-import {Box, Typography} from "@mui/material";
-import {metadataConfig} from "../../metadata.config";
-import {useSelector, useDispatch} from "react-redux";
-import {RootState} from "../../types/data";
-import {fetchMetadataDefinitions} from "../../actions/metadata";
-
+import React, { useEffect } from "react";
+import { Box, Typography } from "@mui/material";
+import { metadataConfig } from "../../metadata.config";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../../types/data";
+import { fetchMetadataDefinitions } from "../../actions/metadata";
 
 type MetadataType = {
-	setMetadata: any,
-}
+	setMetadata: any;
+};
 
 /*
 This is the interface when create new dataset and new files
 Uses only registered metadata definition to populate the form
  */
 export const CreateMetadata = (props: MetadataType) => {
-
-	const {setMetadata} = props;
+	const { setMetadata } = props;
 
 	const dispatch = useDispatch();
-	const getMetadatDefinitions = (name:string|null, skip:number, limit:number) => dispatch(fetchMetadataDefinitions(name, skip,limit));
-	const metadataDefinitionList = useSelector((state: RootState) => state.metadata.metadataDefinitionList);
+	const getMetadatDefinitions = (
+		name: string | null,
+		skip: number,
+		limit: number
+	) => dispatch(fetchMetadataDefinitions(name, skip, limit));
+	const metadataDefinitionList = useSelector(
+		(state: RootState) => state.metadata.metadataDefinitionList
+	);
 
 	useEffect(() => {
 		getMetadatDefinitions(null, 0, 100);
@@ -28,33 +32,35 @@ export const CreateMetadata = (props: MetadataType) => {
 
 	return (
 		<>
-			{
-				metadataDefinitionList.map((metadata,idx) => {
-					return (
-						<Box className="inputGroup" key={idx}>
-							<Typography variant="h6">{metadata.name}</Typography>
-							<Typography variant="subtitle2">{metadata.description}</Typography>
-							{
-								metadata.fields.map((field, idxx) => {
-									return React.cloneElement(
-										// if nothing match fall back to default widget
-										metadataConfig[field.widgetType ?? "NA"] ?? metadataConfig["NA"],
-										{
-											widgetName: metadata.name,
-											fieldName: field.name,
-											options: field.config.options ?? [],
-											setMetadata: setMetadata,
-											initialReadOnly: false,
-											isRequired: field.required,
-											key:idxx
-										}
-									);
-								})
-							}
-						</Box>
-					);
-				})
-			}
+			{metadataDefinitionList.map((metadata, idx) => {
+				return (
+					<Box className="inputGroup" key={idx}>
+						<Typography variant="h6">
+							{metadata.name}{" "}
+							{metadata.fields.some((field) => field.required) && (
+								<span>*</span>
+							)}
+						</Typography>
+						<Typography variant="subtitle2">{metadata.description}</Typography>
+						{metadata.fields.map((field, idxx) => {
+							return React.cloneElement(
+								// if nothing match fall back to default widget
+								metadataConfig[field.widgetType ?? "NA"] ??
+									metadataConfig["NA"],
+								{
+									widgetName: metadata.name,
+									fieldName: field.name,
+									options: field.config.options ?? [],
+									setMetadata: setMetadata,
+									initialReadOnly: false,
+									isRequired: field.required,
+									key: idxx,
+								}
+							);
+						})}
+					</Box>
+				);
+			})}
 		</>
 	);
 };


### PR DESCRIPTION
1. switch the order of metadata and file upload
2. fix the logic of checking required fields --> test by creating "required" and "not required" metadata, within each metadata you can further specify "required" field or "not required" field. The "next" button will enable only when "required" fields are all input
3. align the button to the right
<img width="1237" alt="Pasted Graphic 7" src="https://github.com/clowder-framework/clowder2/assets/13950475/67b66c3b-ce0e-4db3-9a8f-203e84a0f5d9">
<img width="1222" alt="Pasted Graphic 6" src="https://github.com/clowder-framework/clowder2/assets/13950475/65877012-e3fc-4fa8-b14e-f3ed237bb66c">
