### PR TITLE
735 sharing tab bugs

### DIFF
--- a/backend/app/routers/authorization.py
+++ b/backend/app/routers/authorization.py
@@ -159,7 +159,7 @@ async def set_dataset_group_role(
                 )
             ) is not None:
                 if group_id not in auth_db.group_ids:
-                    auth_db.group_ids.append(Ogroup_id)
+                    auth_db.group_ids.append(group_id)
                     for u in group.users:
                         auth_db.user_ids.append(u.user.email)
                     await auth_db.replace()

--- a/backend/app/routers/authorization.py
+++ b/backend/app/routers/authorization.py
@@ -151,7 +151,7 @@ async def set_dataset_group_role(
     if (dataset := await DatasetDB.get(dataset_id)) is not None:
         if (group := await GroupDB.get(group_id)) is not None:
             # First, remove any existing role the group has on the dataset
-            await remove_dataset_group_role(dataset_id, group_id, user_id)
+            await remove_dataset_group_role(dataset_id, group_id, es, user_id)
             if (
                 auth_db := await AuthorizationDB.find_one(
                     AuthorizationDB.dataset_id == PyObjectId(dataset_id),

--- a/backend/app/routers/authorization.py
+++ b/backend/app/routers/authorization.py
@@ -151,7 +151,7 @@ async def set_dataset_group_role(
     if (dataset := await DatasetDB.get(dataset_id)) is not None:
         if (group := await GroupDB.get(group_id)) is not None:
             # First, remove any existing role the group has on the dataset
-            await remove_dataset_group_role(dataset_id, group_id, es, user_id)
+            await remove_dataset_group_role(dataset_id, group_id, es, user_id, allow)
             if (
                 auth_db := await AuthorizationDB.find_one(
                     AuthorizationDB.dataset_id == PyObjectId(dataset_id),
@@ -203,7 +203,7 @@ async def set_dataset_user_role(
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         if (await UserDB.find_one(UserDB.email == username)) is not None:
             # First, remove any existing role the user has on the dataset
-            await remove_dataset_user_role(dataset_id, username, user_id, allow)
+            await remove_dataset_user_role(dataset_id, username, es, user_id, allow)
             auth_db = await AuthorizationDB.find_one(
                 AuthorizationDB.dataset_id == PyObjectId(dataset_id),
                 AuthorizationDB.role == role,

--- a/backend/app/routers/authorization.py
+++ b/backend/app/routers/authorization.py
@@ -163,7 +163,7 @@ async def set_dataset_group_role(
                     for u in group.users:
                         auth_db.user_ids.append(u.user.email)
                     await auth_db.replace()
-                await index_dataset(es, DatasetOut(**dataset.dict()), auth_db.user_ids)
+                await index_dataset(es, DatasetOut(**dataset.dict()), auth_db.user_ids, True)
                 return auth_db.dict()
             else:
                 # Create new role entry for this dataset
@@ -178,7 +178,7 @@ async def set_dataset_group_role(
                     user_ids=user_ids,
                 )
                 await auth_db.insert()
-                await index_dataset(es, DatasetOut(**dataset.dict()), auth_db.user_ids)
+                await index_dataset(es, DatasetOut(**dataset.dict()), auth_db.user_ids, True)
                 return auth_db.dict()
         else:
             raise HTTPException(status_code=404, detail=f"Group {group_id} not found")
@@ -270,7 +270,7 @@ async def remove_dataset_group_role(
                         auth_db.user_ids.remove(u.user.email)
                 await auth_db.save()
                 # Update elasticsearch index with new users
-                await index_dataset(es, DatasetOut(**dataset.dict()), auth_db.user_ids)
+                await index_dataset(es, DatasetOut(**dataset.dict()), auth_db.user_ids, True)
                 return auth_db.dict()
         else:
             raise HTTPException(status_code=404, detail=f"Group {group_id} not found")

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -416,7 +416,7 @@ async def get_file_versions(
         mongo_versions = []
         async for ver in FileVersionDB.find(
             FileVersionDB.file_id == ObjectId(file_id)
-        ).skip(skip).limit(limit):
+        ).sort(-FileVersionDB.created).skip(skip).limit(limit):
             mongo_versions.append(FileVersion(**ver.dict()))
         return mongo_versions
 

--- a/backend/app/search/connect.py
+++ b/backend/app/search/connect.py
@@ -62,6 +62,7 @@ def insert_record(es_client, index_name, doc, id):
         id -- unique key by which you can identify the document when needed
     """
     try:
+        current_doc = str(doc)
         es_client.index(index=index_name, document=doc, id=id)
     except BadRequestError as ex:
         logger.error(str(ex))

--- a/backend/app/search/connect.py
+++ b/backend/app/search/connect.py
@@ -62,7 +62,6 @@ def insert_record(es_client, index_name, doc, id):
         id -- unique key by which you can identify the document when needed
     """
     try:
-        current_doc = str(doc)
         es_client.index(index=index_name, document=doc, id=id)
     except BadRequestError as ex:
         logger.error(str(ex))

--- a/backend/app/tests/test_datasets.py
+++ b/backend/app/tests/test_datasets.py
@@ -3,7 +3,13 @@ import os
 from fastapi.testclient import TestClient
 
 from app.config import settings
-from app.tests.utils import create_dataset, create_user, generate_png, user_example, user_alt
+from app.tests.utils import (
+    create_dataset,
+    create_user,
+    generate_png,
+    user_example,
+    user_alt,
+)
 
 
 def test_create(client: TestClient, headers: dict):
@@ -96,6 +102,7 @@ def test_add_thumbnail(client: TestClient, headers: dict):
     result = resp.json()
     assert result["thumbnail_id"] == thumbnail_id
 
+
 def test_share_dataset(client: TestClient, headers: dict):
     dataset_id = create_dataset(client, headers).get("id")
     response = client.get(
@@ -108,9 +115,7 @@ def test_share_dataset(client: TestClient, headers: dict):
     user_alt_email = user_alt["email"]
     # create user if not exists
     response = client.post(f"{settings.API_V2_STR}/users", json=user_alt)
-    assert (
-            response.status_code == 200 or response.status_code == 409
-    )  # 409 = u
+    assert response.status_code == 200 or response.status_code == 409  # 409 = u
     # share the dataset with the user
     resp = client.post(
         f"{settings.API_V2_STR}/authorizations/datasets/{dataset_id}/user_role/{user_alt_email}/viewer",
@@ -124,6 +129,3 @@ def test_share_dataset(client: TestClient, headers: dict):
         headers=headers,
     )
     assert resp.status_code == 200
-
-
-

--- a/backend/app/tests/test_datasets.py
+++ b/backend/app/tests/test_datasets.py
@@ -3,7 +3,7 @@ import os
 from fastapi.testclient import TestClient
 
 from app.config import settings
-from app.tests.utils import create_dataset, generate_png
+from app.tests.utils import create_dataset, create_user, generate_png, user_example, user_alt
 
 
 def test_create(client: TestClient, headers: dict):
@@ -95,3 +95,35 @@ def test_add_thumbnail(client: TestClient, headers: dict):
 
     result = resp.json()
     assert result["thumbnail_id"] == thumbnail_id
+
+def test_share_dataset(client: TestClient, headers: dict):
+    dataset_id = create_dataset(client, headers).get("id")
+    response = client.get(
+        f"{settings.API_V2_STR}/datasets/{dataset_id}", headers=headers
+    )
+    assert response.status_code == 200
+    dataset_id = response.json().get("id")
+
+    # add a user with a role
+    user_alt_email = user_alt["email"]
+    # create user if not exists
+    response = client.post(f"{settings.API_V2_STR}/users", json=user_alt)
+    assert (
+            response.status_code == 200 or response.status_code == 409
+    )  # 409 = u
+    # share the dataset with the user
+    resp = client.post(
+        f"{settings.API_V2_STR}/authorizations/datasets/{dataset_id}/user_role/{user_alt_email}/viewer",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    # change the role
+    resp = client.post(
+        f"{settings.API_V2_STR}/authorizations/datasets/{dataset_id}/user_role/{user_alt_email}/uploader",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+
+

--- a/backend/app/tests/test_groups.py
+++ b/backend/app/tests/test_groups.py
@@ -132,3 +132,11 @@ def test_member_permissions(client: TestClient, headers: dict):
         headers=u_headers,
     )
     assert response.status_code == 404
+
+    # Change the group role
+    response = client.post(
+        f"{settings.API_V2_STR}/authorizations/datasets/{dataset_id}/group_role/{group_id}/uploader",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json().get("id") is not None


### PR DESCRIPTION
This should fix both sharing tab bugs.

The error for both changing the user role and the group role were that the wrong arguments were getting passed to the remove_dataset_user_role and remove_dataset_group_role methods. That was causing indexing on elasticsearch to fail. Now both should be fixed. 