### PR TITLE
702 thumbnail bytes sometimes doesnt show with 404

### DIFF
--- a/frontend/src/actions/common.js
+++ b/frontend/src/actions/common.js
@@ -51,7 +51,9 @@ export const refreshToken = async (dispatch, originalFunc) => {
 		});
 		const json = await response.json();
 		if (json["access_token"] !== undefined && json["access_token"] !== "none") {
-			cookies.set("Authorization", `Bearer ${json["access_token"]}`);
+			cookies.set("Authorization", `Bearer ${json["access_token"]}`, {
+				path: "/",
+			});
 			V2.OpenAPI.TOKEN = json["access_token"];
 			if (originalFunc) dispatch(originalFunc);
 			else
@@ -139,7 +141,9 @@ export function handleErrorsAuthorization(reason, originalFunc) {
 						json["access_token"] !== undefined &&
 						json["access_token"] !== "none"
 					) {
-						cookies.set("Authorization", `Bearer ${json["access_token"]}`);
+						cookies.set("Authorization", `Bearer ${json["access_token"]}`, {
+							path: "/",
+						});
 						V2.OpenAPI.TOKEN = json["access_token"];
 						dispatch(originalFunc);
 					}

--- a/frontend/src/actions/user.js
+++ b/frontend/src/actions/user.js
@@ -61,7 +61,7 @@ export function _legacy_login(email, password) {
 		cookies.remove("Authorization", { path: "/" });
 
 		if (json["token"] !== undefined && json["token"] !== "none") {
-			cookies.set("Authorization", `Bearer ${json["access_token"]}`, {
+			cookies.set("Authorization", `Bearer ${json["token"]}`, {
 				path: "/",
 			});
 			V2.OpenAPI.TOKEN = json["token"];

--- a/frontend/src/actions/user.js
+++ b/frontend/src/actions/user.js
@@ -61,7 +61,9 @@ export function _legacy_login(email, password) {
 		cookies.remove("Authorization", { path: "/" });
 
 		if (json["token"] !== undefined && json["token"] !== "none") {
-			cookies.set("Authorization", `Bearer ${json["token"]}`);
+			cookies.set("Authorization", `Bearer ${json["access_token"]}`, {
+				path: "/",
+			});
 			V2.OpenAPI.TOKEN = json["token"];
 			return dispatch({
 				type: SET_USER,

--- a/frontend/src/components/auth/RedirectLogin.tsx
+++ b/frontend/src/components/auth/RedirectLogin.tsx
@@ -12,7 +12,7 @@ export const RedirectLogin = (): JSX.Element => {
 
 	useEffect(() => {
 		// restore the origin in cookies
-		cookies.set("origin", origin);
+		cookies.set("origin", origin, { path: "/" });
 		window.location.href = url;
 	}, []);
 

--- a/frontend/src/utils/common.js
+++ b/frontend/src/utils/common.js
@@ -12,8 +12,7 @@ export const isAuthorized = () => {
 	V2.OpenAPI.TOKEN = authorization.replace("Bearer ", "");
 	return (
 		process.env.DEPLOY_ENV === "local" ||
-		(authorization !== undefined &&
-			authorization !== "" &&
+		(authorization !== "" &&
 			authorization !== null &&
 			authorization !== "Bearer none")
 	);


### PR DESCRIPTION
Seems like that I need to store the cookie at the "root" directorate so files on the path can access it. 
Can't seem to trigger 404 anymore with this change; and I looked at the route that has that 404, nothing seems particularly wrong with it.