### PR TITLE
Enabling @context in metadata and metadata definition

### DIFF
--- a/backend/app/models/metadata.py
+++ b/backend/app/models/metadata.py
@@ -101,6 +101,14 @@ class MetadataDefinitionBase(BaseModel):
     class Settings:
         name = "metadata_definitions"
 
+    class Config:
+        # Serialization Config Options
+        # Specify JSON key names
+        # This will rename the field `context` to `@context` in the JSON output
+        fields = {"context": {"alias": "@context"}}
+        # This will allow input by filed name 'context' too along with '@context'
+        allow_population_by_field_name = True
+
 
 class MetadataDefinitionIn(MetadataDefinitionBase):
     pass
@@ -184,6 +192,14 @@ class MetadataBase(BaseModel):
         str
     ]  # This will be fetched from metadata definition if one is provided (shown by GUI)
 
+    class Config:
+        # Serialization Config Options
+        # Specify JSON key names
+        # This will rename the field `context` to `@context` in the JSON output
+        fields = {"context": {"alias": "@context"}}
+        # This will allow input by filed name 'context' too along with '@context'
+        allow_population_by_field_name = True
+
     @validator("context")
     def contexts_are_valid(cls, v):
         if False:
@@ -205,6 +221,12 @@ class MetadataBase(BaseModel):
 
     class Settings:
         name = "metadata"
+
+    class Config:
+        # Serialization Config Options
+        # Specify JSON key names
+        # This will rename the field `context` to `@context` in the JSON output
+        fields = {"context": "@context"}
 
 
 class MetadataIn(MetadataBase):

--- a/backend/app/models/metadata.py
+++ b/backend/app/models/metadata.py
@@ -222,12 +222,6 @@ class MetadataBase(BaseModel):
     class Settings:
         name = "metadata"
 
-    class Config:
-        # Serialization Config Options
-        # Specify JSON key names
-        # This will rename the field `context` to `@context` in the JSON output
-        fields = {"context": "@context"}
-
 
 class MetadataIn(MetadataBase):
     file_version: Optional[int]

--- a/backend/app/models/metadata.py
+++ b/backend/app/models/metadata.py
@@ -2,7 +2,7 @@ import collections.abc
 from datetime import datetime
 from typing import Optional, List, Union
 
-from beanie import Document, PydanticObjectId
+from beanie import Document
 from elasticsearch import Elasticsearch, NotFoundError
 from fastapi import HTTPException
 from pydantic import Field, validator, AnyUrl, BaseModel
@@ -11,7 +11,6 @@ from app.models.listeners import (
     EventListenerIn,
     LegacyEventListenerIn,
     EventListenerOut,
-    ExtractorInfo,
 )
 from app.models.mongomodel import MongoDBRef
 from app.models.users import UserOut
@@ -106,7 +105,7 @@ class MetadataDefinitionBase(BaseModel):
         # Specify JSON key names
         # This will rename the field `context` to `@context` in the JSON output
         fields = {"context": {"alias": "@context"}}
-        # This will allow input by filed name 'context' too along with '@context'
+        # This will allow input by field name 'context' too along with '@context'
         allow_population_by_field_name = True
 
 
@@ -197,7 +196,7 @@ class MetadataBase(BaseModel):
         # Specify JSON key names
         # This will rename the field `context` to `@context` in the JSON output
         fields = {"context": {"alias": "@context"}}
-        # This will allow input by filed name 'context' too along with '@context'
+        # This will allow input by field name 'context' too along with '@context'
         allow_population_by_field_name = True
 
     @validator("context")

--- a/backend/app/tests/test_metadata.py
+++ b/backend/app/tests/test_metadata.py
@@ -10,7 +10,7 @@ from app.tests.utils import create_dataset, upload_file
 metadata_definition = {
     "name": "LatLon",
     "description": "A set of Latitude/Longitude coordinates",
-    "context": [
+    "@context": [
         {
             "longitude": "https://schema.org/longitude",
             "latitude": "https://schema.org/latitude",
@@ -37,7 +37,7 @@ metadata_definition = {
 metadata_definition2 = {
     "name": "AlternativeTitle",
     "description": "Alternative title",
-    "context": [{"title": "https://schema.org/alternateName"}],
+    "@context": [{"title": "https://schema.org/alternateName"}],
     "fields": [
         {
             "name": "alternateName",

--- a/backend/app/tests/test_metadata.py
+++ b/backend/app/tests/test_metadata.py
@@ -85,6 +85,9 @@ def test_dataset_create_metadata_definition(client: TestClient, headers: dict):
         response.status_code == 200 or response.status_code == 409
     )  # 409 = definition already exists
 
+    # check if @context is injected correctly
+    assert response.json().get("@context") is not None
+
     # Create dataset and add metadata to it using new definition
     dataset_id = create_dataset(client, headers).get("id")
     response = client.post(

--- a/frontend/src/openapi/v2/models/MetadataDefinitionIn.ts
+++ b/frontend/src/openapi/v2/models/MetadataDefinitionIn.ts
@@ -42,7 +42,7 @@ import type { MetadataField } from './MetadataField';
                                 export type MetadataDefinitionIn = {
                                     name: string;
                                     description?: string;
-                                    context?: Array<string>;
+                                    '@context'?: Array<string>;
                                     context_url?: string;
                                     fields: Array<MetadataField>;
                                 }

--- a/frontend/src/openapi/v2/models/MetadataDefinitionOut.ts
+++ b/frontend/src/openapi/v2/models/MetadataDefinitionOut.ts
@@ -21,7 +21,7 @@ import type { UserOut } from './UserOut';
 export type MetadataDefinitionOut = {
     name: string;
     description?: string;
-    context?: Array<string>;
+    '@context'?: Array<string>;
     context_url?: string;
     fields: Array<MetadataField>;
     _id?: string;

--- a/frontend/src/openapi/v2/models/MetadataIn.ts
+++ b/frontend/src/openapi/v2/models/MetadataIn.ts
@@ -6,7 +6,7 @@ import type { EventListenerIn } from './EventListenerIn';
 import type { LegacyEventListenerIn } from './LegacyEventListenerIn';
 
 export type MetadataIn = {
-    context?: Array<string>;
+    '@context'?: Array<string>;
     context_url?: string;
     definition?: string;
     content: any;

--- a/frontend/src/openapi/v2/models/MetadataOut.ts
+++ b/frontend/src/openapi/v2/models/MetadataOut.ts
@@ -19,7 +19,7 @@ import type { MongoDBRef } from './MongoDBRef';
  * - [UpdateMethods](https://roman-right.github.io/beanie/api/interfaces/#aggregatemethods)
  */
 export type MetadataOut = {
-    context?: Array<string>;
+    '@context'?: Array<string>;
     context_url?: string;
     definition?: string;
     content: any;

--- a/frontend/src/openapi/v2/models/MetadataPatch.ts
+++ b/frontend/src/openapi/v2/models/MetadataPatch.ts
@@ -6,7 +6,7 @@ import type { EventListenerIn } from './EventListenerIn';
 import type { LegacyEventListenerIn } from './LegacyEventListenerIn';
 
 export type MetadataPatch = {
-    context?: Array<string>;
+    '@context'?: Array<string>;
     context_url?: string;
     definition?: string;
     content: any;


### PR DESCRIPTION
This will enable to input metadata containing @context like jsonld and to show output with @context.This will also use @context while creating entry in mongodb.

To test
1. make sure test_metadata passes.
2. Create a metadata definition. Check in mogodb if it has created an entry with '@context'.
3. See in postman to get the metadata/ metadata defn you just created. It should show output containing '@context'