### PR TITLE
Use less confusing error message on missing updated time

### DIFF
--- a/frontend/src/utils/common.js
+++ b/frontend/src/utils/common.js
@@ -82,7 +82,7 @@ export function parseDate(dateString, formatString = "yyyy-MM-dd HH:mm:ss") {
 			return error["message"];
 		}
 	} else {
-		return "Invalid time value!";
+		return "N/A";
 	}
 }
 


### PR DESCRIPTION
For jobs submitted to non-running extractor, updated time will not be set. rather than showing "Invalid time value!" this will just show "N/A" for that field on the history page.