### PR TITLE
stretched icon when extractor description long

### DIFF
--- a/frontend/src/components/listeners/ListenerItem.tsx
+++ b/frontend/src/components/listeners/ListenerItem.tsx
@@ -52,6 +52,7 @@ export default function ListenerItem(props: ListenerCardProps) {
 				</Typography>
 			</Box>
 			<IconButton
+				disableRipple
 				color="primary"
 				disabled={
 					fileId !== undefined || datasetId !== undefined ? false : true


### PR DESCRIPTION
If the extractor description is long, there was a stretched ellipsis when you hover over the submit arrow button.

For now I have just disabled the ripple effect, but I am working on figuring out if I can just change its size. This is why this is draft.

To test, use an extractor with a long description. 