### PR TITLE
788 duplicated extractor registration when extractor version updated

### DIFF
--- a/backend/heartbeat_listener.py
+++ b/backend/heartbeat_listener.py
@@ -40,9 +40,8 @@ async def callback(message: AbstractIncomingMessage):
             new_version = extractor_db.version
             if version.parse(new_version) > version.parse(existing_version):
                 # if this is a new version, add it to the database
-                new_extractor = await extractor_db.insert()
-                # TODO - for now we are not deleting an older version of the extractor, just adding a new one
-                # await existing_extractor.delete()
+                extractor_db.id = existing_extractor.id
+                new_extractor = await extractor_db.replace()
                 extractor_out = EventListenerOut(**new_extractor.dict())
                 logger.info(
                     "%s updated from %s to %s"

--- a/backend/heartbeat_listener.py
+++ b/backend/heartbeat_listener.py
@@ -41,6 +41,7 @@ async def callback(message: AbstractIncomingMessage):
             if version.parse(new_version) > version.parse(existing_version):
                 # if this is a new version, add it to the database
                 extractor_db.id = existing_extractor.id
+                extractor_db.created = existing_extractor.created
                 new_extractor = await extractor_db.replace()
                 extractor_out = EventListenerOut(**new_extractor.dict())
                 logger.info(


### PR DESCRIPTION
This is now fixed. If a new version is running, it replaces the existing version. 

The 'created' field is taken from the 'created' of the original extractor, since it seemed to make sense that 'created' should always be initial registration and 'modified' is the time of the latest version. 

In order to test, you will need to kill the docker container for the heartbeat_listener.py and run it locally. 