### PR TITLE
792 clear previous log before switching extraction logs

### DIFF
--- a/frontend/src/actions/listeners.js
+++ b/frontend/src/actions/listeners.js
@@ -1,133 +1,202 @@
-import {V2} from "../openapi";
-import {handleErrors} from "./common";
+import { V2 } from "../openapi";
+import { handleErrors } from "./common";
 
 export const RECEIVE_LISTENERS = "RECEIVE_LISTENERS";
 
-export function fetchListeners(skip=0, limit=21, category=null, label=null){
+export function fetchListeners(
+	skip = 0,
+	limit = 21,
+	category = null,
+	label = null
+) {
 	return (dispatch) => {
 		// TODO: Parameters for dates? paging?
-		return V2.ListenersService.getListenersApiV2ListenersGet(skip, limit, category, label)
-			.then(json => {
+		return V2.ListenersService.getListenersApiV2ListenersGet(
+			skip,
+			limit,
+			category,
+			label
+		)
+			.then((json) => {
 				dispatch({
 					type: RECEIVE_LISTENERS,
 					listeners: json,
 					receivedAt: Date.now(),
 				});
 			})
-			.catch(reason => {
-				dispatch(handleErrors(reason, fetchListeners(skip, limit, category, label)));
+			.catch((reason) => {
+				dispatch(
+					handleErrors(reason, fetchListeners(skip, limit, category, label))
+				);
 			});
-
 	};
 }
 
 export const SEARCH_LISTENERS = "SEARCH_LISTENERS";
 
-export function queryListeners(text, skip=0, limit=21){
+export function queryListeners(text, skip = 0, limit = 21) {
 	return (dispatch) => {
 		// TODO: Parameters for dates? paging?
-		return V2.ListenersService.searchListenersApiV2ListenersSearchGet(text, skip, limit)
-			.then(json => {
+		return V2.ListenersService.searchListenersApiV2ListenersSearchGet(
+			text,
+			skip,
+			limit
+		)
+			.then((json) => {
 				dispatch({
 					type: SEARCH_LISTENERS,
 					listeners: json,
 					receivedAt: Date.now(),
 				});
 			})
-			.catch(reason => {
+			.catch((reason) => {
 				dispatch(handleErrors(reason, queryListeners(text, skip, limit)));
 			});
-
 	};
 }
 
 export const RECEIVE_LISTENER_CATEGORIES = "RECEIVE_LISTENER_CATEGORIES";
-export function fetchListenerCategories(){
+
+export function fetchListenerCategories() {
 	return (dispatch) => {
 		return V2.ListenersService.listCategoriesApiV2ListenersCategoriesGet()
-		.then(json => {
+			.then((json) => {
 				dispatch({
 					type: RECEIVE_LISTENER_CATEGORIES,
 					categories: json,
 					receivedAt: Date.now(),
 				});
 			})
-			.catch(reason => {
+			.catch((reason) => {
 				dispatch(handleErrors(reason, fetchListenerCategories()));
 			});
-	}
+	};
 }
 
 export const RECEIVE_LISTENER_LABELS = "RECEIVE_LISTENER_LABELS";
-export function fetchListenerLabels(){
+
+export function fetchListenerLabels() {
 	return (dispatch) => {
 		return V2.ListenersService.listDefaultLabelsApiV2ListenersDefaultLabelsGet()
-		.then(json => {
+			.then((json) => {
 				dispatch({
 					type: RECEIVE_LISTENER_LABELS,
 					labels: json,
 					receivedAt: Date.now(),
 				});
 			})
-			.catch(reason => {
+			.catch((reason) => {
 				dispatch(handleErrors(reason, fetchListenerLabels()));
 			});
-	}
+	};
 }
 
-
 export const RECEIVE_LISTENER_JOBS = "RECEIVE_LISTENER_JOBS";
-export function fetchListenerJobs(listenerId, status, userId=null, fileId=null, datasetId = null,
-	created, skip=0, limit=100){
+
+export function fetchListenerJobs(
+	listenerId,
+	status,
+	userId = null,
+	fileId = null,
+	datasetId = null,
+	created,
+	skip = 0,
+	limit = 100
+) {
 	return (dispatch) => {
-		return V2.JobsService.getAllJobSummaryApiV2JobsGet(listenerId, status, userId, fileId, datasetId, created,
-			skip, limit)
-		.then(json => {
+		return V2.JobsService.getAllJobSummaryApiV2JobsGet(
+			listenerId,
+			status,
+			userId,
+			fileId,
+			datasetId,
+			created,
+			skip,
+			limit
+		)
+			.then((json) => {
 				dispatch({
 					type: RECEIVE_LISTENER_JOBS,
 					jobs: json,
 					receivedAt: Date.now(),
 				});
 			})
-			.catch(reason => {
-				dispatch(handleErrors(reason, fetchListenerLabels(listenerId, status, userId=null, fileId=null,
-					datasetId = null, created, skip=0, limit=100)));
+			.catch((reason) => {
+				dispatch(
+					handleErrors(
+						reason,
+						fetchListenerLabels(
+							listenerId,
+							status,
+							(userId = null),
+							(fileId = null),
+							(datasetId = null),
+							created,
+							(skip = 0),
+							(limit = 100)
+						)
+					)
+				);
 			});
-	}
+	};
 }
 
-
 export const FETCH_JOB_SUMMARY = "FETCH_JOB_SUMMARY";
-export function fetchJobSummary(jobId){
+
+export function fetchJobSummary(jobId) {
 	return (dispatch) => {
 		return V2.JobsService.getJobSummaryApiV2JobsJobIdSummaryGet(jobId)
-			.then(json => {
+			.then((json) => {
 				dispatch({
 					type: FETCH_JOB_SUMMARY,
 					currJobSummary: json,
 					receivedAt: Date.now(),
 				});
 			})
-			.catch(reason => {
+			.catch((reason) => {
 				dispatch(handleErrors(reason, fetchListenerLabels()));
 			});
-	}
+	};
 }
 
+export const RESET_JOB_SUMMARY = "RESET_JOB_SUMMARY";
+
+export function resetJobSummary() {
+	return (dispatch) => {
+		dispatch({
+			type: RESET_JOB_SUMMARY,
+			currJobSummary: {},
+			receivedAt: Date.now(),
+		});
+	};
+}
 
 export const FETCH_JOB_UPDATES = "FETCH_JOB_UPDATES";
-export function fetchJobUpdates(jobId){
+
+export function fetchJobUpdates(jobId) {
 	return (dispatch) => {
 		return V2.JobsService.getJobUpdatesApiV2JobsJobIdUpdatesGet(jobId)
-			.then(json => {
+			.then((json) => {
 				dispatch({
 					type: FETCH_JOB_UPDATES,
 					currJobUpdates: json,
 					receivedAt: Date.now(),
 				});
 			})
-			.catch(reason => {
+			.catch((reason) => {
 				dispatch(handleErrors(reason, fetchListenerLabels()));
 			});
-	}
+	};
+}
+
+export const RESET_JOB_UPDATES = "RESET_JOB_UPDATES";
+
+export function resetJobUpdates() {
+	return (dispatch) => {
+		dispatch({
+			type: RESET_JOB_UPDATES,
+			currJobUpdates: [],
+			receivedAt: Date.now(),
+		});
+	};
 }

--- a/frontend/src/components/listeners/ExtractorStatus.tsx
+++ b/frontend/src/components/listeners/ExtractorStatus.tsx
@@ -15,7 +15,12 @@ import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { parseDate } from "../../utils/common";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../types/data";
-import { fetchJobSummary, fetchJobUpdates } from "../../actions/listeners";
+import {
+	fetchJobSummary,
+	fetchJobUpdates,
+	resetJobSummary,
+	resetJobUpdates,
+} from "../../actions/listeners";
 import config from "../../app.config";
 
 function Row(props: { summary: any; updates: any }) {
@@ -97,6 +102,8 @@ export default function ExtractorStatus(props: { job_id: any }) {
 		dispatch(fetchJobSummary(job_id));
 	const jobUpdatesFetch = (job_id: string | undefined) =>
 		dispatch(fetchJobUpdates(job_id));
+	const jobSummaryReset = () => dispatch(resetJobSummary());
+	const jobUpdatesReset = () => dispatch(resetJobUpdates());
 
 	const summary = useSelector(
 		(state: RootState) => state.listener.currJobSummary
@@ -106,12 +113,22 @@ export default function ExtractorStatus(props: { job_id: any }) {
 	);
 
 	useEffect(() => {
-		jobSummaryFetch(job_id);
-		jobUpdatesFetch(job_id);
+		// clear previous job's log
+		jobSummaryReset();
+		jobUpdatesReset();
 
-		const interval = setInterval(() => {
+		// immediate fetch
+		if (job_id.length > 0) {
 			jobSummaryFetch(job_id);
 			jobUpdatesFetch(job_id);
+		}
+
+		// set the interval to fetch the job's log
+		const interval = setInterval(() => {
+			if (job_id.length > 0) {
+				jobSummaryFetch(job_id);
+				jobUpdatesFetch(job_id);
+			}
 		}, config.extractorInterval);
 
 		return () => clearInterval(interval);

--- a/frontend/src/components/listeners/ExtractorStatus.tsx
+++ b/frontend/src/components/listeners/ExtractorStatus.tsx
@@ -106,11 +106,12 @@ export default function ExtractorStatus(props: { job_id: any }) {
 	);
 
 	useEffect(() => {
+		jobSummaryFetch(job_id);
+		jobUpdatesFetch(job_id);
+
 		const interval = setInterval(() => {
-			if (job_id.length > 0) {
-				jobSummaryFetch(job_id);
-				jobUpdatesFetch(job_id);
-			}
+			jobSummaryFetch(job_id);
+			jobUpdatesFetch(job_id);
 		}, config.extractorInterval);
 
 		return () => clearInterval(interval);

--- a/frontend/src/reducers/listeners.ts
+++ b/frontend/src/reducers/listeners.ts
@@ -1,11 +1,18 @@
 import {
-	RECEIVE_LISTENERS, SEARCH_LISTENERS, RECEIVE_LISTENER_CATEGORIES,
-	RECEIVE_LISTENER_LABELS, RECEIVE_LISTENER_JOBS, FETCH_JOB_SUMMARY, FETCH_JOB_UPDATES
+	FETCH_JOB_SUMMARY,
+	FETCH_JOB_UPDATES,
+	RECEIVE_LISTENER_CATEGORIES,
+	RECEIVE_LISTENER_JOBS,
+	RECEIVE_LISTENER_LABELS,
+	RECEIVE_LISTENERS,
+	RESET_JOB_SUMMARY,
+	RESET_JOB_UPDATES,
+	SEARCH_LISTENERS,
 } from "../actions/listeners";
 import { SUBMIT_DATASET_EXTRACTION } from "../actions/dataset";
 import { SUBMIT_FILE_EXTRACTION } from "../actions/file";
-import {DataAction} from "../types/action";
-import {ListenerState} from "../types/data";
+import { DataAction } from "../types/action";
+import { ListenerState } from "../types/data";
 
 const defaultState: ListenerState = {
 	listeners: [],
@@ -14,31 +21,43 @@ const defaultState: ListenerState = {
 	jobs: [],
 	currJobSummary: [],
 	currJobUpdates: [],
-	currJobId: ""
+	currJobId: "",
 };
 
 const listeners = (state = defaultState, action: DataAction) => {
 	switch (action.type) {
 		case RECEIVE_LISTENERS:
-			return Object.assign({}, state, {listeners: action.listeners});
+			return Object.assign({}, state, { listeners: action.listeners });
 		case SEARCH_LISTENERS:
-			return Object.assign({}, state, {listeners: action.listeners});
+			return Object.assign({}, state, { listeners: action.listeners });
 		case RECEIVE_LISTENER_CATEGORIES:
-			return Object.assign({}, state, {categories: action.categories});
+			return Object.assign({}, state, { categories: action.categories });
 		case RECEIVE_LISTENER_LABELS:
-			return Object.assign({}, state, {labels: action.labels});
+			return Object.assign({}, state, { labels: action.labels });
 		case RECEIVE_LISTENER_JOBS:
-			return Object.assign({}, state, {jobs: action.jobs});
-        case FETCH_JOB_SUMMARY:
-            return Object.assign({}, state, {currJobSummary: action.currJobSummary});
-        case FETCH_JOB_UPDATES:
-            return Object.assign({}, state, {currJobUpdates: action.currJobUpdates});
-        case SUBMIT_DATASET_EXTRACTION:
-            return Object.assign({}, state, {currJobId: action.job_id});
-        case SUBMIT_FILE_EXTRACTION:
-            return Object.assign({}, state, {currJobId: action.job_id});
-        default:
-            return state;
+			return Object.assign({}, state, { jobs: action.jobs });
+		case FETCH_JOB_SUMMARY:
+			return Object.assign({}, state, {
+				currJobSummary: action.currJobSummary,
+			});
+		case RESET_JOB_SUMMARY:
+			return Object.assign({}, state, {
+				currJobSummary: {},
+			});
+		case FETCH_JOB_UPDATES:
+			return Object.assign({}, state, {
+				currJobUpdates: action.currJobUpdates,
+			});
+		case RESET_JOB_UPDATES:
+			return Object.assign({}, state, {
+				currJobUpdates: action.currJobUpdates,
+			});
+		case SUBMIT_DATASET_EXTRACTION:
+			return Object.assign({}, state, { currJobId: action.job_id });
+		case SUBMIT_FILE_EXTRACTION:
+			return Object.assign({}, state, { currJobId: action.job_id });
+		default:
+			return state;
 	}
 };
 

--- a/frontend/src/types/action.ts
+++ b/frontend/src/types/action.ts
@@ -9,6 +9,8 @@ import {
 	AuthorizationBase,
 	DatasetOut as Dataset,
 	DatasetRoles,
+	EventListenerJobOut,
+	EventListenerJobUpdateOut,
 	FileOut as FileSummary,
 	FileVersion,
 	GroupOut as Group,
@@ -340,7 +342,7 @@ interface RECEIVE_LISTENER_LABELS {
 
 interface RECEIVE_LISTENER_JOBS {
 	type: "RECEIVE_LISTENER_JOBS";
-	jobs: [];
+	jobs: EventListenerJobUpdateOut[];
 }
 
 interface SUBMIT_FILE_EXTRACTION {
@@ -355,12 +357,22 @@ interface SUBMIT_DATASET_EXTRACTION {
 
 interface FETCH_JOB_SUMMARY {
 	type: "FETCH_JOB_SUMMARY";
-	currJobSummary: [];
+	currJobSummary: EventListenerJobOut;
+}
+
+interface RESET_JOB_SUMMARY {
+	type: "RESET_JOB_SUMMARY";
+	currJobSummary: EventListenerJobOut;
 }
 
 interface FETCH_JOB_UPDATES {
 	type: "FETCH_JOB_UPDATES";
-	currJobUpdates: [];
+	currJobUpdates: EventListenerJobUpdateOut[];
+}
+
+interface RESET_JOB_UPDATES {
+	type: "RESET_JOB_UPDATES";
+	currJobUpdates: EventListenerJobUpdateOut[];
 }
 
 interface CREATE_GROUP {
@@ -505,7 +517,9 @@ export type DataAction =
 	| SUBMIT_FILE_EXTRACTION
 	| SUBMIT_DATASET_EXTRACTION
 	| FETCH_JOB_SUMMARY
+	| RESET_JOB_SUMMARY
 	| FETCH_JOB_UPDATES
+	| RESET_JOB_UPDATES
 	| CREATE_GROUP
 	| RECEIVE_GROUPS
 	| SEARCH_GROUPS


### PR DESCRIPTION
When you switching between different extractors, those log should clear out immediately then reflect the new changes
<img width="794" alt="image" src="https://github.com/clowder-framework/clowder2/assets/13950475/7b179197-0b5d-4b08-a6af-73a79c69c4b9">
