### PR TITLE
804 move searchbox to top for metadata definition and group page

### DIFF
--- a/frontend/src/components/groups/Groups.tsx
+++ b/frontend/src/components/groups/Groups.tsx
@@ -7,8 +7,6 @@ import {
 	DialogContent,
 	DialogTitle,
 	Grid,
-	IconButton,
-	InputBase,
 } from "@mui/material";
 import { RootState } from "../../types/data";
 import { useDispatch, useSelector } from "react-redux";
@@ -16,7 +14,7 @@ import {
 	fetchGroups,
 	searchGroups as searchGroupsAction,
 } from "../../actions/group";
-import { ArrowBack, ArrowForward, SearchOutlined } from "@material-ui/icons";
+import { ArrowBack, ArrowForward } from "@material-ui/icons";
 import { Link } from "react-router-dom";
 import Paper from "@mui/material/Paper";
 import Table from "@mui/material/Table";
@@ -26,12 +24,11 @@ import TableCell from "@mui/material/TableCell";
 import TableBody from "@mui/material/TableBody";
 import TableContainer from "@mui/material/TableContainer";
 import GroupsIcon from "@mui/icons-material/Groups";
-import { theme } from "../../theme";
 import Layout from "../Layout";
-import { MainBreadcrumbs } from "../navigation/BreadCrumb";
 import GroupAddIcon from "@mui/icons-material/GroupAdd";
 import { CreateGroup } from "./CreateGroup";
 import { ErrorModal } from "../errors/ErrorModal";
+import { GenericSearchBox } from "../search/GenericSearchBox";
 
 export function Groups() {
 	// Redux connect equivalent
@@ -54,14 +51,6 @@ export function Groups() {
 	const [nextDisabled, setNextDisabled] = useState<boolean>(false);
 	const [searchTerm, setSearchTerm] = useState<string>("");
 	const [createGroupOpen, setCreateGroupOpen] = useState<boolean>(false);
-
-	// for breadcrumb
-	const paths = [
-		{
-			name: "Groups",
-			url: "/groups",
-		},
-	];
 
 	// component did mount
 	useEffect(() => {
@@ -124,11 +113,8 @@ export function Groups() {
 					<CreateGroup setCreateGroupOpen={setCreateGroupOpen} />
 				</DialogContent>
 			</Dialog>
-			{/*breadcrumb*/}
 			<Grid container>
-				<Grid item xs={8} sx={{ display: "flex", alignItems: "center" }}>
-					<MainBreadcrumbs paths={paths} />
-				</Grid>
+				<Grid item xs={8}></Grid>
 				<Grid item xs={4}>
 					<Button
 						variant="contained"
@@ -142,49 +128,19 @@ export function Groups() {
 					</Button>
 				</Grid>
 			</Grid>
-			<br />
-			<Grid container>
-				<Grid item xs={3}>
-					<Box
-						component="form"
-						sx={{
-							p: "2px 4px",
-							display: "flex",
-							alignItems: "left",
-							backgroundColor: theme.palette.primary.contrastText,
-							width: "80%",
-						}}
-					>
-						<InputBase
-							sx={{ ml: 1, flex: 1 }}
-							placeholder="keyword for group"
-							inputProps={{
-								"aria-label": "Type in keyword to search for group",
-							}}
-							onChange={(e) => {
-								setSearchTerm(e.target.value);
-							}}
-							onKeyDown={(e) => {
-								if (e.key === "Enter") {
-									e.preventDefault();
-									searchGroups(searchTerm, skip, limit);
-								}
-							}}
-							value={searchTerm}
-						/>
-						<IconButton
-							type="button"
-							sx={{ p: "10px" }}
-							aria-label="search"
-							onClick={() => {
-								searchGroups(searchTerm, skip, limit);
-							}}
-						>
-							<SearchOutlined />
-						</IconButton>
-					</Box>
+			<Grid container spacing={4}>
+				<Grid item xs={12}>
+					<GenericSearchBox
+						title="Search for Groups"
+						searchPrompt="keyword for group"
+						setSearchTerm={setSearchTerm}
+						searchTerm={searchTerm}
+						searchFunction={searchGroups}
+						skip={skip}
+						limit={limit}
+					/>
 				</Grid>
-				<Grid item xs={9}>
+				<Grid item xs={12}>
 					<TableContainer component={Paper}>
 						<Table sx={{ minWidth: 650 }} aria-label="simple table">
 							<TableHead>
@@ -219,7 +175,9 @@ export function Groups() {
 									return (
 										<TableRow
 											key={group.id}
-											sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+											sx={{
+												"&:last-child td, &:last-child th": { border: 0 },
+											}}
 										>
 											<TableCell scope="row" key={group.id}>
 												<Button component={Link} to={`/groups/${group.id}`}>

--- a/frontend/src/components/groups/Groups.tsx
+++ b/frontend/src/components/groups/Groups.tsx
@@ -128,7 +128,7 @@ export function Groups() {
 					</Button>
 				</Grid>
 			</Grid>
-			<Grid container spacing={4}>
+			<Grid container spacing={2}>
 				<Grid item xs={12}>
 					<GenericSearchBox
 						title="Search for Groups"

--- a/frontend/src/components/metadata/MetadataDefinitions.tsx
+++ b/frontend/src/components/metadata/MetadataDefinitions.tsx
@@ -8,7 +8,6 @@ import {
 	DialogTitle,
 	Grid,
 	IconButton,
-	InputBase,
 } from "@mui/material";
 import { RootState } from "../../types/data";
 import { useDispatch, useSelector } from "react-redux";
@@ -16,7 +15,7 @@ import {
 	fetchMetadataDefinitions as fetchMetadataDefinitionsAction,
 	searchMetadataDefinitions as searchMetadataDefinitionsAction,
 } from "../../actions/metadata";
-import { ArrowBack, ArrowForward, SearchOutlined } from "@material-ui/icons";
+import { ArrowBack, ArrowForward } from "@material-ui/icons";
 import Paper from "@mui/material/Paper";
 import Table from "@mui/material/Table";
 import TableHead from "@mui/material/TableHead";
@@ -25,14 +24,13 @@ import TableCell from "@mui/material/TableCell";
 import TableBody from "@mui/material/TableBody";
 import TableContainer from "@mui/material/TableContainer";
 import InfoIcon from "@mui/icons-material/Info";
-import { theme } from "../../theme";
 import Layout from "../Layout";
-import { MainBreadcrumbs } from "../navigation/BreadCrumb";
 import { ErrorModal } from "../errors/ErrorModal";
 import { CreateMetadataDefinition } from "./CreateMetadataDefinition";
 import DeleteIcon from "@mui/icons-material/Delete";
 import DeleteMetadataDefinitionModal from "./DeleteMetadataDefinitionModal";
 import { Link } from "react-router-dom";
+import { GenericSearchBox } from "../search/GenericSearchBox";
 
 export function MetadataDefinitions() {
 	// Redux connect equivalent
@@ -66,14 +64,6 @@ export function MetadataDefinitions() {
 	] = useState<boolean>(false);
 	const [selectedMetadataDefinition, setSelectedMetadataDefinition] =
 		useState();
-
-	// for breadcrumb
-	const paths = [
-		{
-			name: "Metadata Definitions",
-			url: "/metadata-definitions",
-		},
-	];
 
 	// component did mount
 	useEffect(() => {
@@ -149,11 +139,8 @@ export function MetadataDefinitions() {
 					/>
 				</DialogContent>
 			</Dialog>
-			{/*breadcrumb*/}
 			<Grid container>
-				<Grid item xs={8} sx={{ display: "flex", alignItems: "center" }}>
-					<MainBreadcrumbs paths={paths} />
-				</Grid>
+				<Grid item xs={8}></Grid>
 				<Grid item xs={4}>
 					<Button
 						variant="contained"
@@ -168,49 +155,19 @@ export function MetadataDefinitions() {
 				</Grid>
 			</Grid>
 			<br />
-			<Grid container>
-				<Grid item xs={3}>
-					<Box
-						component="form"
-						sx={{
-							p: "2px 4px",
-							display: "flex",
-							alignItems: "left",
-							backgroundColor: theme.palette.primary.contrastText,
-							width: "80%",
-						}}
-					>
-						<InputBase
-							sx={{ ml: 1, flex: 1 }}
-							placeholder="keyword for metadat definition"
-							inputProps={{
-								"aria-label":
-									"Type in keyword to search for metadat definition",
-							}}
-							onChange={(e) => {
-								setSearchTerm(e.target.value);
-							}}
-							onKeyDown={(e) => {
-								if (e.key === "Enter") {
-									e.preventDefault();
-									searchMetadataDefinitions(searchTerm, skip, limit);
-								}
-							}}
-							value={searchTerm}
-						/>
-						<IconButton
-							type="button"
-							sx={{ p: "10px" }}
-							aria-label="search"
-							onClick={() => {
-								searchMetadataDefinitions(searchTerm, skip, limit);
-							}}
-						>
-							<SearchOutlined />
-						</IconButton>
-					</Box>
+			<Grid container spacing={2}>
+				<Grid item xs={12}>
+					<GenericSearchBox
+						title="Search for Metadata Definitions"
+						searchPrompt="keyword for metadata definition"
+						setSearchTerm={setSearchTerm}
+						searchTerm={searchTerm}
+						searchFunction={searchMetadataDefinitions}
+						skip={skip}
+						limit={limit}
+					/>
 				</Grid>
-				<Grid item xs={9}>
+				<Grid item xs={12}>
 					<TableContainer component={Paper}>
 						<Table sx={{ minWidth: 650 }} aria-label="simple table">
 							<TableHead>

--- a/frontend/src/components/search/GenericSearchBox.tsx
+++ b/frontend/src/components/search/GenericSearchBox.tsx
@@ -28,7 +28,6 @@ export function GenericSearchBox(props: GenericSearchBoxProps) {
 		<>
 			<Typography
 				sx={{
-					mb: 1,
 					fontSize: "1rem",
 					color: theme.palette.primary.light,
 					fontWeight: 600,

--- a/frontend/src/components/search/GenericSearchBox.tsx
+++ b/frontend/src/components/search/GenericSearchBox.tsx
@@ -1,0 +1,81 @@
+import Typography from "@mui/material/Typography";
+import { theme } from "../../theme";
+import { Box, IconButton, InputBase } from "@mui/material";
+import { SearchOutlined } from "@material-ui/icons";
+import React from "react";
+
+type GenericSearchBoxProps = {
+	title: string;
+	searchPrompt: string;
+	setSearchTerm: any;
+	searchTerm: string;
+	searchFunction: any;
+	skip?: number;
+	limit?: number;
+};
+
+export function GenericSearchBox(props: GenericSearchBoxProps) {
+	const {
+		title,
+		searchPrompt,
+		setSearchTerm,
+		searchTerm,
+		searchFunction,
+		skip,
+		limit,
+	} = props;
+	return (
+		<>
+			<Typography
+				sx={{
+					mb: 1,
+					fontSize: "1rem",
+					color: theme.palette.primary.light,
+					fontWeight: 600,
+				}}
+			>
+				{title}
+			</Typography>
+			<Box
+				component="form"
+				sx={{
+					border: "1px solid #ced4da",
+					borderRadius: "6px",
+					mb: 2,
+					p: "2px 4px",
+					display: "flex",
+					alignItems: "left",
+					backgroundColor: theme.palette.primary.contrastText,
+				}}
+			>
+				<InputBase
+					sx={{ ml: 1, flex: 1 }}
+					placeholder={searchPrompt}
+					inputProps={{
+						"aria-label": { searchPrompt },
+					}}
+					onChange={(e) => {
+						setSearchTerm(e.target.value);
+					}}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.preventDefault();
+							searchFunction(searchTerm, skip, limit);
+						}
+					}}
+					value={searchTerm}
+				/>
+				<IconButton
+					type="button"
+					sx={{ p: "10px" }}
+					aria-label="search"
+					onClick={() => {
+						searchFunction(searchTerm, skip, limit);
+					}}
+				>
+					<SearchOutlined />
+				</IconButton>
+			</Box>
+		</>
+	);
+}


### PR DESCRIPTION
I wrapped the search widget with title and prompt to a generic component.
Move it up to the top and clean up the groups and metadata definition page a little bit.

<img width="1785" alt="image" src="https://github.com/clowder-framework/clowder2/assets/13950475/c7887154-3460-4205-8231-f6bc71c8a5f3">
<img width="1749" alt="image" src="https://github.com/clowder-framework/clowder2/assets/13950475/4afce165-6089-40ef-8574-abeb19ef1a55">
