### PR TITLE
need image tag for heartbeat and listeners

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -139,7 +139,7 @@ services:
       - elasticsearch:/usr/share/elasticsearch/data
     
   extractors-heartbeat:
-    image: "clowder/clowder2-heartbeat:main"
+    image: "clowder/clowder2-heartbeat:latest"
     build:
       context: backend
       dockerfile: heartbeat.Dockerfile
@@ -155,7 +155,7 @@ services:
       - rabbitmq
 
   extractors-messages:
-    image: "clowder/clowder2-messages:main"
+    image: "clowder/clowder2-messages:latest"
     build:
       context: backend
       dockerfile: messages.Dockerfile

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -139,7 +139,7 @@ services:
       - elasticsearch:/usr/share/elasticsearch/data
     
   extractors-heartbeat:
-    image: "clowder/clowder2-heartbeat"
+    image: "clowder/clowder2-heartbeat:main"
     build:
       context: backend
       dockerfile: heartbeat.Dockerfile

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -155,7 +155,7 @@ services:
       - rabbitmq
 
   extractors-messages:
-    image: "clowder/clowder2-messages"
+    image: "clowder/clowder2-messages:main"
     build:
       context: backend
       dockerfile: messages.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "traefik.http.routers.frontend.priority=1"
 
   extractors-heartbeat:
-    image: "clowder/clowder2-heartbeat"
+    image: "clowder/clowder2-heartbeat:main"
     build:
       context: backend
       dockerfile: heartbeat.Dockerfile
@@ -109,7 +109,7 @@ services:
       - rabbitmq
 
   extractors-messages:
-    image: "clowder/clowder2-messages"
+    image: "clowder/clowder2-messages:main"
     build:
       context: backend
       dockerfile: messages.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "traefik.http.routers.frontend.priority=1"
 
   extractors-heartbeat:
-    image: "clowder/clowder2-heartbeat:latest"
+    image: "clowder/clowder2-heartbeat:main"
     build:
       context: backend
       dockerfile: heartbeat.Dockerfile
@@ -109,7 +109,7 @@ services:
       - rabbitmq
 
   extractors-messages:
-    image: "clowder/clowder2-messages:latest"
+    image: "clowder/clowder2-messages:main"
     build:
       context: backend
       dockerfile: messages.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - "traefik.http.routers.frontend.priority=1"
 
   extractors-heartbeat:
-    image: "clowder/clowder2-heartbeat:main"
+    image: "clowder/clowder2-heartbeat:latest"
     build:
       context: backend
       dockerfile: heartbeat.Dockerfile
@@ -109,7 +109,7 @@ services:
       - rabbitmq
 
   extractors-messages:
-    image: "clowder/clowder2-messages:main"
+    image: "clowder/clowder2-messages:latest"
     build:
       context: backend
       dockerfile: messages.Dockerfile


### PR DESCRIPTION
Without an image tag my local heartbeat and listeners docker images were not being updated, causing issues. 

I found that adding the tags fix the problem, so I added them for these 2 docker images based on what looked like the most current tags. Updated for docker-dev and docker-compose.