### PR TITLE
Add external Keycloak functionality 

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,4 @@
+
 from typing import List
 
 from pydantic import BaseSettings, AnyHttpUrl
@@ -43,6 +44,7 @@ class Settings(BaseSettings):
     auth_base = "http://localhost:8080"
     auth_realm = "clowder"
     auth_client_id = "clowder2-backend"
+    auth_redirect_uri = "http://localhost:80/api/v2/auth"
     auth_url = f"{auth_base}/keycloak/realms/{auth_realm}/protocol/openid-connect/auth?client_id={auth_client_id}&response_type=code"
     oauth2_scheme_auth_url = f"{auth_base}/auth/realms/{auth_realm}/protocol/openid-connect/auth?client_id={auth_client_id}&response_type=code"
     # scope=openid email&redirect_uri=http://<domain.com>/<redirect-path>&kc_locale=<two-digit-lang-code>

--- a/backend/app/routers/keycloak.py
+++ b/backend/app/routers/keycloak.py
@@ -33,14 +33,13 @@ async def register() -> RedirectResponse:
 @router.get("/login")
 async def login() -> RedirectResponse:
     """Redirect to keycloak login page."""
-    kc_auth_url = keycloak_openid.auth_url(
-            redirect_uri=settings.auth_redirect_uri,
-            scope="openid email",
-            state=token_urlsafe(30*3//4)
+    return RedirectResponse(
+            keycloak_openid.auth_url(
+                redirect_uri=settings.auth_redirect_uri,
+                scope="openid email",
+                state=token_urlsafe(32) 
+            )
         )
-    
-    print(kc_auth_url)
-    return RedirectResponse(kc_auth_url)
 
 
 @router.get("/logout")
@@ -113,7 +112,7 @@ async def auth(code: str) -> RedirectResponse:
         code=code,
         redirect_uri=settings.auth_redirect_uri,
     )
-    print(token_body)
+
     access_token = token_body["access_token"]
 
     # create user in db if it doesn't already exist; get the user_id
@@ -159,12 +158,12 @@ async def auth(code: str) -> RedirectResponse:
 
     # redirect to frontend
     auth_url = f"{settings.frontend_url}/auth"
-    print(auth_url)
+
     response = RedirectResponse(url=auth_url)
-    print(response)
+
     response.set_cookie("Authorization", value=f"Bearer {access_token}")
     logger.info(f"Authenticated by keycloak. Redirecting to {auth_url}")
-    print('here')
+
     return response
 
 

--- a/backend/app/routers/keycloak.py
+++ b/backend/app/routers/keycloak.py
@@ -17,6 +17,7 @@ from app.keycloak_auth import (
 )
 from app.models.tokens import TokenDB
 from app.models.users import UserIn, UserDB
+from secrets import token_urlsafe
 
 router = APIRouter()
 security = HTTPBearer()
@@ -32,7 +33,14 @@ async def register() -> RedirectResponse:
 @router.get("/login")
 async def login() -> RedirectResponse:
     """Redirect to keycloak login page."""
-    return RedirectResponse(settings.auth_url)
+    kc_auth_url = keycloak_openid.auth_url(
+            redirect_uri=settings.auth_redirect_uri,
+            scope="openid email",
+            state=token_urlsafe(30*3//4)
+        )
+    
+    print(kc_auth_url)
+    return RedirectResponse(kc_auth_url)
 
 
 @router.get("/logout")
@@ -100,15 +108,12 @@ async def auth(code: str) -> RedirectResponse:
     """Redirect endpoint Keycloak redirects to after login."""
     logger.info(f"In /api/v2/auth")
     # get token from Keycloak
-    payload = (
-        f"grant_type=authorization_code&code={code}"
-        f"&redirect_uri={settings.auth_url}&client_id={settings.auth_client_id}"
+    token_body = keycloak_openid.token(
+        grant_type='authorization_code',
+        code=code,
+        redirect_uri=settings.auth_redirect_uri,
     )
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-    token_response = requests.request(
-        "POST", settings.auth_token_url, data=payload, headers=headers
-    )
-    token_body = json.loads(token_response.content)
+    print(token_body)
     access_token = token_body["access_token"]
 
     # create user in db if it doesn't already exist; get the user_id
@@ -154,9 +159,12 @@ async def auth(code: str) -> RedirectResponse:
 
     # redirect to frontend
     auth_url = f"{settings.frontend_url}/auth"
+    print(auth_url)
     response = RedirectResponse(url=auth_url)
+    print(response)
     response.set_cookie("Authorization", value=f"Bearer {access_token}")
     logger.info(f"Authenticated by keycloak. Redirecting to {auth_url}")
+    print('here')
     return response
 
 

--- a/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
@@ -61,9 +61,15 @@ spec:
             - name: MONGO_DATABASE
               value: {{ .Values.mongodb.database }}
             - name: CLOWDER2_URL
-              value: http://{{ .Values.hostname }}
+              value: {{ .Values.hostname }}
             - name: auth_base
               value: $(CLOWDER2_URL)
+            - name: auth_realm
+              value: {{ .Values.auth.realm }}
+            - name: auth_client_id
+              value: {{ .Values.auth.clientID }}
+            - name: auth_redirect_uri
+              value: {{ .Values.auth.redirectURI }}
             - name: auth_url
               value: $(CLOWDER2_URL)/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
             - name: oauth2_scheme_auth_url
@@ -73,7 +79,7 @@ spec:
             - name: auth_token_url
               value: http://{{ include "clowder2.name" .}}-keycloak-headless:8080/keycloak/realms/clowder/protocol/openid-connect/token
             - name: auth_server_url
-              value: http://{{ include "clowder2.name" .}}-keycloak-headless:8080/keycloak/
+              value: {{ .Values.auth.server  }}
             - name: keycloak_base
               value: $(CLOWDER2_URL)/api
             - name: frontend_url

--- a/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: MONGO_DATABASE
               value: {{ .Values.mongodb.database }}
             - name: CLOWDER2_URL
-              value: {{ .Values.hostname }}
+              value: http://{{ .Values.hostname }}
             - name: auth_base
               value: $(CLOWDER2_URL)
             - name: auth_realm

--- a/deployments/kubernetes/charts/clowder2/values.yaml
+++ b/deployments/kubernetes/charts/clowder2/values.yaml
@@ -1,5 +1,11 @@
 hostname: clowder2.localhost
 
+auth:
+  server: clowder2.localhost/keycloak/
+  realm: clowder
+  clientID: clowder2-backend
+  redirectURI: clowder2.localhost/api/v2/auth
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Premise

Currently, clowder2 relies on an internal keycloak instance for handling authentication, but does not have functionality for a using an existing keycloak instance. This should be pretty simple but requires a few changes to some of the requests made back to the keycloak server for oauth2 flow.

## Changes
- Change the `auth` and `token` requests to use the `python-keycloak` packages `KeycloakOpenID` object to construct these URLs/requests.
- Add an `auth_redirect_uri` environment variable to change