### PR TITLE
892 latest main branch is not building the frontend image correct

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,7 @@ services:
       - "traefik.http.routers.backend.priority=5"
 
   frontend:
-#    image: "clowder/clowder2-frontend:2.0.0-beta.1"
-    image: "clowder/clowder2-frontend:test-build"
+    image: "clowder/clowder2-frontend:2.0.0-beta.1"
     restart: unless-stopped
     build:
       context: ./frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,8 @@ services:
       - "traefik.http.routers.backend.priority=5"
 
   frontend:
-    image: "clowder/clowder2-frontend:2.0.0-beta.1"
+#    image: "clowder/clowder2-frontend:2.0.0-beta.1"
+    image: "clowder/clowder2-frontend:test-build"
     restart: unless-stopped
     build:
       context: ./frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,7 +28,6 @@ RUN npm run build
 
 FROM nginx:alpine as clowder-runtime
 
-RUN apk add --no-cache jq
 RUN rm -rf /usr/share/nginx/html/ && \
   mkdir /usr/share/nginx/html && \
   mkdir /usr/share/nginx/html/public \

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -32,7 +32,7 @@ import { ExtractionHistory } from "./components/listeners/ExtractionHistory";
 import { fetchDatasetRole, fetchFileRole } from "./actions/authorization";
 import { PageNotFound } from "./components/errors/PageNotFound";
 import { Forbidden } from "./components/errors/Forbidden";
-import { ApiKeys } from "./components/ApiKeys/ApiKey";
+import { ApiKeys } from "./components/apikeys/ApiKey";
 import { Profile } from "./components/users/Profile";
 import { ManageUsers } from "./components/users/ManageUsers";
 import config from "./app.config";


### PR DESCRIPTION
The typo is causing the build failure.
-----
To test:
1. Build a test image by `cd frontend` and run `docker build -t clowder/clowder2-frontend:test-build .`
2. point the frontend in `docker-compose.yml` to this image `image: "clowder/clowder2-frontend:test-build"`
3. docker compose up

Some helpful command e.g. get into the built image to check nginx folder
`docker run -it clowder/clowder2-frontend:test-build /bin/sh`
You should see all the bundles there
<img width="1428" alt="image" src="https://github.com/clowder-framework/clowder2/assets/13950475/62681fce-49af-490c-9e73-31cc1cbcc5d5">


