### PR TITLE
upgrade keycloak to v20

### DIFF
--- a/deployments/kubernetes/charts/clowder2/files/realm.json
+++ b/deployments/kubernetes/charts/clowder2/files/realm.json
@@ -197,7 +197,8 @@
         "acr",
         "roles",
         "profile",
-        "email"
+        "email",
+        "openid"
       ],
       "optionalClientScopes": [
         "address",
@@ -471,6 +472,18 @@
           }
         }
       ]
+    },
+    {
+      "id": "27b15f8c-ea65-4288-bfd5-bd88eb1d05cf",
+      "name": "openid",
+      "description": "",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      }
     },
     {
       "id": "9489cfcc-4415-4d08-a792-988d995a3edb",
@@ -942,7 +955,8 @@
     "email",
     "roles",
     "web-origins",
-    "acr"
+    "acr",
+    "openid"
   ],
   "defaultOptionalClientScopes": [
     "offline_access",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,7 +75,7 @@ services:
         POSTGRES_PASSWORD: password
 
   keycloak:
-      image: quay.io/keycloak/keycloak:19.0
+      image: quay.io/keycloak/keycloak:20.0
       volumes:
         - ./scripts/keycloak/clowder-realm-dev.json:/opt/keycloak/data/import/realm.json:ro
         - ./scripts/keycloak/clowder-theme/:/opt/keycloak/themes/clowder-theme/:ro

--- a/scripts/keycloak/clowder-realm-dev.json
+++ b/scripts/keycloak/clowder-realm-dev.json
@@ -332,7 +332,8 @@
         "web-origins",
         "roles",
         "profile",
-        "email"
+        "email",
+        "openid"
       ],
       "optionalClientScopes": [
         "address",
@@ -505,6 +506,18 @@
           }
         }
       ]
+    },
+    {
+      "id": "27b15f8c-ea65-4288-bfd5-bd88eb1d05cf",
+      "name": "openid",
+      "description": "",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      }
     },
     {
       "id": "aeeafc25-f5bc-4f8d-88c5-0b4150415d50",
@@ -931,7 +944,8 @@
     "profile",
     "email",
     "roles",
-    "web-origins"
+    "web-origins",
+    "openid"
   ],
   "defaultOptionalClientScopes": [
     "offline_access",

--- a/scripts/keycloak/clowder-realm-prod.json
+++ b/scripts/keycloak/clowder-realm-prod.json
@@ -610,7 +610,8 @@
         "web-origins",
         "roles",
         "profile",
-        "email"
+        "email",
+        "openid"
       ],
       "optionalClientScopes": [
         "address",
@@ -806,6 +807,18 @@
           }
         }
       ]
+    },
+    {
+      "id": "27b15f8c-ea65-4288-bfd5-bd88eb1d05cf",
+      "name": "openid",
+      "description": "",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      }
     },
     {
       "id": "aeeafc25-f5bc-4f8d-88c5-0b4150415d50",
@@ -1234,7 +1247,8 @@
     "email",
     "roles",
     "web-origins",
-    "acr"
+    "acr",
+    "openid"
   ],
   "defaultOptionalClientScopes": [
     "offline_access",

--- a/scripts/keycloak/full-kube-clowder-realm-prod.json
+++ b/scripts/keycloak/full-kube-clowder-realm-prod.json
@@ -316,7 +316,8 @@
         "web-origins",
         "roles",
         "profile",
-        "email"
+        "email",
+        "openid"
       ],
       "optionalClientScopes": [
         "address",
@@ -471,6 +472,18 @@
           }
         }
       ]
+    },
+    {
+      "id": "27b15f8c-ea65-4288-bfd5-bd88eb1d05cf",
+      "name": "openid",
+      "description": "",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      }
     },
     {
       "id": "9489cfcc-4415-4d08-a792-988d995a3edb",
@@ -942,7 +955,8 @@
     "email",
     "roles",
     "web-origins",
-    "acr"
+    "acr",
+    "openid"
   ],
   "defaultOptionalClientScopes": [
     "offline_access",

--- a/scripts/keycloak/mini-clowder-realm-dev.json
+++ b/scripts/keycloak/mini-clowder-realm-dev.json
@@ -61,7 +61,8 @@
         "web-origins",
         "roles",
         "profile",
-        "email"
+        "email",
+        "openid"
       ],
       "optionalClientScopes": [
         "address",

--- a/scripts/keycloak/mini-clowder-realm-prod.json
+++ b/scripts/keycloak/mini-clowder-realm-prod.json
@@ -63,7 +63,8 @@
         "web-origins",
         "roles",
         "profile",
-        "email"
+        "email",
+        "openid"
       ],
       "optionalClientScopes": [
         "address",

--- a/scripts/keycloak/mini-kube-clowder-realm-prod.json
+++ b/scripts/keycloak/mini-kube-clowder-realm-prod.json
@@ -36,7 +36,8 @@
         "web-origins",
         "roles",
         "profile",
-        "email"
+        "email",
+        "openid"
       ],
       "optionalClientScopes": [
         "address",


### PR DESCRIPTION
With keycloak v20, openid is not included as a default scope, which caused the error reported by the upgrade.

On the issue there is a video that shows how I configured keycloak through the admi console to work.

I did an export of the realm.json and I believe that all the keycloak json files are now working and correct. The dev one definitely works. 

Marking this draft as I need to check whether the other jsons work. 