### PR TITLE
981 clowder2 register link on the topbar doesnt work

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -49,8 +49,7 @@ class Settings(BaseSettings):
     # scope=openid email&redirect_uri=http://<domain.com>/<redirect-path>&kc_locale=<two-digit-lang-code>
     auth_register_url = (
         f"{auth_base}/keycloak/realms/{auth_realm}/protocol/openid-connect/registrations?client_id"
-        f"={auth_client_id}&response_type=code"
-        f"=&redirect_uri={auth_redirect_uri}"
+        f"={auth_client_id}&response_type=code&redirect_uri={auth_redirect_uri}"
     )
     auth_token_url = (
         f"{auth_base}/keycloak/realms/{auth_realm}/protocol/openid-connect/token"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     auth_register_url = (
         f"{auth_base}/keycloak/realms/{auth_realm}/protocol/openid-connect/registrations?client_id"
         f"={auth_client_id}&response_type=code"
+        f"=&redirect_uri={auth_redirect_uri}"
     )
     auth_token_url = (
         f"{auth_base}/keycloak/realms/{auth_realm}/protocol/openid-connect/token"

--- a/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
@@ -75,7 +75,7 @@ spec:
             - name: oauth2_scheme_auth_url
               value: http://{{ include "clowder2.name" .}}-keycloak-headless:8080/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
             - name: auth_register_url
-              value: $(CLOWDER2_URL)/keycloak/realms/clowder/protocol/openid-connect/registrations?client_id=clowder2-backend&response_type=code
+              value: $(CLOWDER2_URL)/keycloak/realms/clowder/protocol/openid-connect/registrations?client_id=clowder2-backend&response_type=code&redirect_uri=$(auth_redirect_uri)
             - name: auth_token_url
               value: http://{{ include "clowder2.name" .}}-keycloak-headless:8080/keycloak/realms/clowder/protocol/openid-connect/token
             - name: auth_server_url

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       auth_redirect_uri: http://localhost:80/api/v2/auth
       auth_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
       oauth2_scheme_auth_url: http://keycloak:8080/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
-      auth_register_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/registrations?client_id=clowder2-backend&response_type=code
+      auth_register_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/registrations?client_id=clowder2-backend&response_type=code&redirect_uri=${auth_redirect_uri}
       auth_token_url: http://keycloak:8080/keycloak/realms/clowder/protocol/openid-connect/token
       auth_server_url: http://keycloak:8080/keycloak/
       keycloak_base: http://localhost/api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       auth_redirect_uri: http://localhost:80/api/v2/auth
       auth_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
       oauth2_scheme_auth_url: http://keycloak:8080/keycloak/realms/clowder/protocol/openid-connect/auth?client_id=clowder2-backend&response_type=code
-      auth_register_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/registrations?client_id=clowder2-backend&response_type=code&redirect_uri=${auth_redirect_uri}
+      auth_register_url: http://localhost/keycloak/realms/clowder/protocol/openid-connect/registrations?client_id=clowder2-backend&response_type=code&redirect_uri=http://localhost:80/api/v2/auth
       auth_token_url: http://keycloak:8080/keycloak/realms/clowder/protocol/openid-connect/token
       auth_server_url: http://keycloak:8080/keycloak/
       keycloak_base: http://localhost/api


### PR DESCRIPTION
For some reason we are missing the redirect_uri. Maybe it's related to keycloak upgrade?