### PR TITLE
fix typo in roles endpoint; disable sharing with myself

### DIFF
--- a/backend/app/routers/authorization.py
+++ b/backend/app/routers/authorization.py
@@ -336,7 +336,7 @@ async def remove_dataset_user_role(
         raise HTTPException(status_code=404, detail=f"Dataset {dataset_id} not found")
 
 
-@router.get("/datasets/{dataset_id}/roles}", response_model=DatasetRoles)
+@router.get("/datasets/{dataset_id}/roles", response_model=DatasetRoles)
 async def get_dataset_roles(
     dataset_id: str,
     allow: bool = Depends(Authorization("editor")),

--- a/frontend/src/components/datasets/ShareDatasetModal.tsx
+++ b/frontend/src/components/datasets/ShareDatasetModal.tsx
@@ -55,6 +55,8 @@ export default function ShareDatasetModal(props: ShareDatasetModalProps) {
 	const getRoles = (datasetId: string | undefined) =>
 		dispatch(fetchDatasetRoles(datasetId));
 
+	const myProfile = useSelector((state: RootState) => state.user.profile);
+
 	useEffect(() => {
 		prefixSearchAllUsers("", 0, 10);
 	}, []);
@@ -67,10 +69,14 @@ export default function ShareDatasetModal(props: ShareDatasetModalProps) {
 	useEffect(() => {
 		setOptions(
 			users.reduce((list: string[], user: UserOut) => {
-				return [...list, user.email];
+				// don't include the current user
+				if (user.email !== myProfile.email) {
+					return [...list, user.email];
+				}
+				return list;
 			}, [])
 		);
-	}, [users]);
+	}, [users, myProfile.email]);
 
 	const onShare = async () => {
 		await setUserRole(datasetId, email, role);

--- a/frontend/src/openapi/v2/services/AuthorizationService.ts
+++ b/frontend/src/openapi/v2/services/AuthorizationService.ts
@@ -265,7 +265,7 @@ export class AuthorizationService {
     ): CancelablePromise<DatasetRoles> {
         return __request({
             method: 'GET',
-            path: `/api/v2/authorizations/datasets/${datasetId}/roles}`,
+            path: `/api/v2/authorizations/datasets/${datasetId}/roles`,
             errors: {
                 422: `Validation Error`,
             },

--- a/openapi.json
+++ b/openapi.json
@@ -1583,14 +1583,14 @@
         ]
       }
     },
-    "/api/v2/authorizations/datasets/{dataset_id}/roles}": {
+    "/api/v2/authorizations/datasets/{dataset_id}/roles": {
       "get": {
         "tags": [
           "authorization"
         ],
         "summary": "Get Dataset Roles",
         "description": "Get a list of all users and groups that have assigned roles on this dataset.",
-        "operationId": "get_dataset_roles_api_v2_authorizations_datasets__dataset_id__roles__get",
+        "operationId": "get_dataset_roles_api_v2_authorizations_datasets__dataset_id__roles_get",
         "parameters": [
           {
             "required": true,


### PR DESCRIPTION
- Fixed a typo on the "role" endpoint url.. there was a trailing "}" 
- Filter out the current user's email in the share options to make sure it can't be shared with the current user. 

<img width="1079" alt="image" src="https://github.com/clowder-framework/clowder2/assets/13950475/78017709-82e8-445c-a664-e4058f3da4c6">
