### PR TITLE
breadcrumb in the public components point to the wrong frontend routes

### DIFF
--- a/frontend/src/components/datasets/PublicDataset.tsx
+++ b/frontend/src/components/datasets/PublicDataset.tsx
@@ -117,7 +117,7 @@ export const PublicDataset = (): JSX.Element => {
 		const tmpPaths = [
 			{
 				name: about["name"],
-				url: `/public_datasets/${datasetId}`,
+				url: `/public/datasets/${datasetId}`,
 			},
 		];
 
@@ -125,7 +125,7 @@ export const PublicDataset = (): JSX.Element => {
 			for (const folderBread of publicFolderPath) {
 				tmpPaths.push({
 					name: folderBread["folder_name"],
-					url: `/public_datasets/${datasetId}?folder=${folderBread["folder_id"]}`,
+					url: `/public/datasets/${datasetId}?folder=${folderBread["folder_id"]}`,
 				});
 			}
 		} else {

--- a/frontend/src/components/files/PublicFile.tsx
+++ b/frontend/src/components/files/PublicFile.tsx
@@ -121,7 +121,7 @@ export const PublicFile = (): JSX.Element => {
 		const tmpPaths = [
 			{
 				name: about["name"],
-				url: `/public_datasets/${datasetId}`,
+				url: `/public/datasets/${datasetId}`,
 			},
 		];
 
@@ -129,7 +129,7 @@ export const PublicFile = (): JSX.Element => {
 			for (const folderBread of folderPath) {
 				tmpPaths.push({
 					name: folderBread["folder_name"],
-					url: `/public_datasets/${datasetId}?folder=${folderBread["folder_id"]}`,
+					url: `/public/datasets/${datasetId}?folder=${folderBread["folder_id"]}`,
 				});
 			}
 		} else {


### PR DESCRIPTION
To test:
1. create a dataset with nested folders and files
2. change its status to public
3. **logout**
4. explore this public datasets's folder and file and click their breadcrumbs to see if it leads to the right location

e.g.
<img width="364" alt="image" src="https://github.com/clowder-framework/clowder2/assets/13950475/435955cb-f8d1-44b0-b972-ab9014f50542">
<img width="707" alt="image" src="https://github.com/clowder-framework/clowder2/assets/13950475/43a3d70c-257a-4514-8e9d-6c74dd32b797">
