### PR TITLE
1020 modify extractor description UI

### DIFF
--- a/frontend/src/components/listeners/ListenerInfo.tsx
+++ b/frontend/src/components/listeners/ListenerInfo.tsx
@@ -13,6 +13,14 @@ type ListenerInfoProps = {
 	defaultExpanded?: boolean;
 };
 
+const customStyles = {
+	authorInfo: {
+		color: theme.palette.info.main,
+		fontSize: "12px",
+		margin: "0.75em 0 0.75em 0",
+	},
+};
+
 export const ListenerInfo = (props: ListenerInfoProps) => {
 	const { selectedExtractor, defaultExpanded } = props;
 
@@ -32,18 +40,18 @@ export const ListenerInfo = (props: ListenerInfoProps) => {
 					<></>
 				)}
 			</Box>
-			{selectedExtractor && selectedExtractor["description"] ? (
-				<Typography>{selectedExtractor["description"]}</Typography>
-			) : null}
 			{selectedExtractor &&
 			selectedExtractor["created"] &&
 			selectedExtractor["properties"] &&
 			selectedExtractor["properties"]["author"] ? (
-				<ClowderFootnote style={{ color: theme.palette.info.main }}>
+				<ClowderFootnote style={customStyles.authorInfo}>
 					{`Created by ${
 						selectedExtractor["properties"]["author"]
 					} at ${parseDate(selectedExtractor["created"])}`}
 				</ClowderFootnote>
+			) : null}
+			{selectedExtractor && selectedExtractor["description"] ? (
+				<Typography>{selectedExtractor["description"]}</Typography>
 			) : null}
 			{selectedExtractor ? (
 				<ListenerInfoDetails

--- a/frontend/src/components/listeners/ListenerItem.tsx
+++ b/frontend/src/components/listeners/ListenerItem.tsx
@@ -75,7 +75,7 @@ export default function ListenerItem(props: ListenerCardProps) {
 					<Typography
 						sx={{
 							padding: "2em",
-							color: theme.palette.primary.light,
+							color: theme.palette.info.main,
 							fontSize: "14px",
 						}}
 					>

--- a/frontend/src/components/listeners/ListenerItem.tsx
+++ b/frontend/src/components/listeners/ListenerItem.tsx
@@ -64,7 +64,7 @@ export default function ListenerItem(props: ListenerCardProps) {
 				!extractor["alive"] ? (
 					<Typography
 						sx={{
-							padding: "0.5em",
+							padding: "2em",
 							color: "rgba(0, 0, 0, 0.26)",
 							fontSize: "14px",
 						}}
@@ -74,7 +74,7 @@ export default function ListenerItem(props: ListenerCardProps) {
 				) : (
 					<Typography
 						sx={{
-							padding: "0.5em",
+							padding: "2em",
 							color: theme.palette.primary.light,
 							fontSize: "14px",
 						}}


### PR DESCRIPTION
Simple UI changes as requested in issue #1020, to test just go the extractor tab and check the extractors are displayed in the following style 
![image](https://github.com/clowder-framework/clowder2/assets/16596733/736e718f-154e-4bd6-b113-33838f58c762)

Also in the extractor info modal, check the spacing and color of the author info 
![image](https://github.com/clowder-framework/clowder2/assets/16596733/bd75d021-818d-4f5e-914c-195aa8e4a86a)
