### PR TITLE
1039 dataset versions show in links

### DIFF
--- a/frontend/src/actions/dataset.js
+++ b/frontend/src/actions/dataset.js
@@ -266,7 +266,9 @@ export const GET_FREEZE_DATASETS = "GET_FREEZE_DATASETS";
 export function getFreezeDatasets(datasetId, skip = 0, limit = 21) {
 	return (dispatch) => {
 		return V2.DatasetsService.getFreezeDatasetsApiV2DatasetsDatasetIdFreezeGet(
-			datasetId
+			datasetId,
+			skip,
+			limit
 		)
 			.then((json) => {
 				dispatch({

--- a/frontend/src/app.config.ts
+++ b/frontend/src/app.config.ts
@@ -29,6 +29,7 @@ interface Config {
 	defaultExtractors: number;
 	defaultExtractionJobs: number;
 	defaultMetadataDefintionPerPage: number;
+	defaultVersionPerPage: number;
 }
 
 const config: Config = <Config>{};
@@ -89,5 +90,6 @@ config["defaultApikeyPerPage"] = 5;
 config["defaultExtractors"] = 5;
 config["defaultExtractionJobs"] = 5;
 config["defaultMetadataDefintionPerPage"] = 5;
+config["defaultVersionPerPage"] = 3;
 
 export default config;

--- a/frontend/src/components/datasets/Dataset.tsx
+++ b/frontend/src/components/datasets/Dataset.tsx
@@ -537,11 +537,7 @@ export const Dataset = (): JSX.Element => {
 					</TabPanel>
 				</Grid>
 				<Grid item>
-					<DatasetVersions
-						currDataset={dataset}
-						setSnackBarMessage={setSnackBarMessage}
-						setSnackBarOpen={setSnackBarOpen}
-					/>
+					<DatasetVersions currDataset={dataset} />
 					<>
 						<Typography variant="h5" gutterBottom>
 							License

--- a/frontend/src/components/datasets/Dataset.tsx
+++ b/frontend/src/components/datasets/Dataset.tsx
@@ -177,6 +177,17 @@ export const Dataset = (): JSX.Element => {
 	}, [datasetId, searchParams, adminMode, dataset.license_id]);
 
 	useEffect(() => {
+		setSnackBarOpen(true);
+		setSnackBarMessage(
+			`Viewing dataset version ${
+				dataset.id === dataset.origin_id
+					? "current unreleased"
+					: dataset.frozen_version_num
+			}.`
+		);
+	}, [dataset]);
+
+	useEffect(() => {
 		if (
 			newFrozenDataset &&
 			newFrozenDataset.frozen &&

--- a/frontend/src/components/datasets/DatasetVersions.tsx
+++ b/frontend/src/components/datasets/DatasetVersions.tsx
@@ -9,9 +9,9 @@ import { parseDate } from "../../utils/common";
 import { theme } from "../../theme";
 
 export const DatasetVersions = (props) => {
-	const { currDataset, setSnackBarMessage, setSnackBarOpen } = props;
+	const { currDataset } = props;
 	const dispatch = useDispatch();
-	const [currPageNum, setCurrPageNum] = useState<number>(1);
+	const [currVersionPageNum, setCurrVersionPageNum] = useState<number>(1);
 	const [limit] = useState<number>(config.defaultVersionPerPage);
 	const [skip, setSkip] = useState<number>(0);
 
@@ -34,20 +34,30 @@ export const DatasetVersions = (props) => {
 	const history = useNavigate();
 
 	useEffect(() => {
+		const storedPageNum = localStorage.getItem("currVersionPageNum");
+		if (storedPageNum) {
+			const pageNum = parseInt(storedPageNum, 10);
+			setCurrVersionPageNum(pageNum);
+			setSkip((pageNum - 1) * limit);
+		}
+	}, []);
+
+	useEffect(() => {
 		let datasetId;
 		if (currDataset.origin_id) datasetId = currDataset.origin_id;
 		else datasetId = currDataset.id;
 		if (datasetId) getFreezeDatasets(datasetId, skip, limit);
-	}, [currDataset, latestFrozenVersionNum]);
+	}, [currDataset, latestFrozenVersionNum, skip, limit]);
 
 	const handleVersionChange = (selectedDatasetId: string) => {
+		localStorage.setItem("currVersionPageNum", currVersionPageNum.toString());
 		history(`/datasets/${selectedDatasetId}`);
 	};
 
 	const handlePageChange = (_: ChangeEvent<unknown>, value: number) => {
 		const originDatasetId = currDataset.origin_id;
 		const newSkip = (value - 1) * limit;
-		setCurrPageNum(value);
+		setCurrVersionPageNum(value);
 		setSkip(newSkip);
 		getFreezeDatasets(originDatasetId, newSkip, limit);
 	};
@@ -119,10 +129,9 @@ export const DatasetVersions = (props) => {
 				<Box display="flex" justifyContent="center" sx={{ m: 1 }}>
 					<Pagination
 						count={Math.ceil(pageMetadata.total_count / limit)}
-						page={currPageNum}
+						page={currVersionPageNum}
 						onChange={handlePageChange}
-						shape="rounded"
-						variant="outlined"
+						shape="circular"
 					/>
 				</Box>
 			) : (

--- a/frontend/src/components/datasets/DatasetVersions.tsx
+++ b/frontend/src/components/datasets/DatasetVersions.tsx
@@ -39,12 +39,7 @@ export const DatasetVersions = (props) => {
 		if (datasetId) getFreezeDatasets(datasetId, 0, limit);
 	}, [currDataset, latestFrozenVersionNum]);
 
-	const handleVersionChange = (
-		selectedDatasetId: string,
-		selectedVersionNum: string
-	) => {
-		setSnackBarMessage(`Viewing dataset version ${selectedVersionNum}.`);
-		setSnackBarOpen(true);
+	const handleVersionChange = (selectedDatasetId: string) => {
 		history(`/datasets/${selectedDatasetId}`);
 	};
 
@@ -65,7 +60,7 @@ export const DatasetVersions = (props) => {
 					<Link
 						component="button"
 						onClick={() => {
-							handleVersionChange(currDataset.origin_id, "current unreleased");
+							handleVersionChange(currDataset.origin_id);
 						}}
 						sx={{
 							color:
@@ -90,7 +85,7 @@ export const DatasetVersions = (props) => {
 						<Link
 							component="button"
 							onClick={() => {
-								handleVersionChange(dataset.id, dataset.frozen_version_num);
+								handleVersionChange(dataset.id);
 							}}
 							sx={{
 								color:

--- a/frontend/src/components/datasets/DatasetVersions.tsx
+++ b/frontend/src/components/datasets/DatasetVersions.tsx
@@ -13,6 +13,7 @@ export const DatasetVersions = (props) => {
 	const dispatch = useDispatch();
 	const [currPageNum, setCurrPageNum] = useState<number>(1);
 	const [limit] = useState<number>(config.defaultVersionPerPage);
+	const [skip, setSkip] = useState<number>(0);
 
 	const getFreezeDatasets = (
 		datasetId: string | undefined,
@@ -36,7 +37,7 @@ export const DatasetVersions = (props) => {
 		let datasetId;
 		if (currDataset.origin_id) datasetId = currDataset.origin_id;
 		else datasetId = currDataset.id;
-		if (datasetId) getFreezeDatasets(datasetId, 0, limit);
+		if (datasetId) getFreezeDatasets(datasetId, skip, limit);
 	}, [currDataset, latestFrozenVersionNum]);
 
 	const handleVersionChange = (selectedDatasetId: string) => {
@@ -47,6 +48,7 @@ export const DatasetVersions = (props) => {
 		const originDatasetId = currDataset.origin_id;
 		const newSkip = (value - 1) * limit;
 		setCurrPageNum(value);
+		setSkip(newSkip);
 		getFreezeDatasets(originDatasetId, newSkip, limit);
 	};
 

--- a/frontend/src/components/datasets/DatasetVersions.tsx
+++ b/frontend/src/components/datasets/DatasetVersions.tsx
@@ -6,12 +6,12 @@ import { getFreezeDatasets as getFreezeDatasetsAction } from "../../actions/data
 import { RootState } from "../../types/data";
 import config from "../../app.config";
 import { parseDate } from "../../utils/common";
-import { ClowderFootnote } from "../styledComponents/ClowderFootnote";
+import { theme } from "../../theme";
 
 export const DatasetVersions = (props) => {
 	const { currDataset, setSnackBarMessage, setSnackBarOpen } = props;
 	const dispatch = useDispatch();
-	const [selectedId, setSelectedId] = useState("");
+	const [selectedId, setSelectedId] = useState(currDataset.id);
 	const [currPageNum, setCurrPageNum] = useState<number>(1);
 	const [limit] = useState<number>(config.defaultVersionPerPage);
 
@@ -45,6 +45,7 @@ export const DatasetVersions = (props) => {
 		selectedDatasetId: string,
 		selectedVersionNum: string
 	) => {
+		setSelectedId(selectedDatasetId);
 		history(`/datasets/${selectedDatasetId}`);
 		setSnackBarMessage(`Viewing dataset version ${selectedVersionNum}.`);
 		setSnackBarOpen(true);
@@ -70,9 +71,15 @@ export const DatasetVersions = (props) => {
 							handleVersionChange(currDataset.origin_id, "current unreleased");
 						}}
 						sx={{
-							color: selectedId === currDataset.origin_id ? "red" : "blue",
-							pointerEvents: selectedId === currDataset.id ? "none" : "auto",
+							color:
+								selectedId === currDataset.origin_id
+									? theme.palette.info.main
+									: theme.palette.primary.main,
+							pointerEvents:
+								selectedId === currDataset.origin_id ? "none" : "auto",
 							textDecoration: "none",
+							fontWeight:
+								selectedId === currDataset.origin_id ? "bold" : "normal",
 							"&:hover": {
 								textDecoration: "underline",
 							},
@@ -89,9 +96,13 @@ export const DatasetVersions = (props) => {
 								handleVersionChange(dataset.id, dataset.frozen_version_num);
 							}}
 							sx={{
-								color: selectedId === dataset.id ? "red" : "blue",
+								color:
+									selectedId === dataset.id
+										? theme.palette.info.main
+										: theme.palette.primary.main,
 								pointerEvents: selectedId === dataset.id ? "none" : "auto",
 								textDecoration: "none",
+								fontWeight: selectedId === dataset.id ? "bold" : "normal",
 								"&:hover": {
 									textDecoration: "underline",
 								},
@@ -99,9 +110,14 @@ export const DatasetVersions = (props) => {
 						>
 							Version {dataset.frozen_version_num}
 						</Link>
-						<ClowderFootnote>
-							Last Modified: {parseDate(dataset.modified)}
-						</ClowderFootnote>
+						<Box>
+							<Typography
+								variant="caption"
+								sx={{ color: "text.primary.light" }}
+							>
+								{parseDate(dataset.modified)}
+							</Typography>
+						</Box>
 					</Box>
 				))}
 			</Box>

--- a/frontend/src/components/datasets/DatasetVersions.tsx
+++ b/frontend/src/components/datasets/DatasetVersions.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, useEffect, useState } from "react";
 import { Box, Link, Pagination, Typography } from "@mui/material";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { getFreezeDatasets as getFreezeDatasetsAction } from "../../actions/dataset";
 import { RootState } from "../../types/data";
@@ -9,6 +9,10 @@ import { parseDate } from "../../utils/common";
 import { theme } from "../../theme";
 
 export const DatasetVersions = (props) => {
+	// search parameters
+	const [searchParams] = useSearchParams();
+	const currVersionPageNumParam = searchParams.get("currVersionPageNum");
+
 	const { currDataset } = props;
 	const dispatch = useDispatch();
 	const [currVersionPageNum, setCurrVersionPageNum] = useState<number>(1);
@@ -34,13 +38,12 @@ export const DatasetVersions = (props) => {
 	const history = useNavigate();
 
 	useEffect(() => {
-		const storedPageNum = localStorage.getItem("currVersionPageNum");
-		if (storedPageNum) {
-			const pageNum = parseInt(storedPageNum, 10);
+		if (currVersionPageNumParam) {
+			const pageNum = parseInt(currVersionPageNumParam, 10);
 			setCurrVersionPageNum(pageNum);
 			setSkip((pageNum - 1) * limit);
 		}
-	}, []);
+	}, [currVersionPageNumParam]);
 
 	useEffect(() => {
 		let datasetId;
@@ -50,8 +53,15 @@ export const DatasetVersions = (props) => {
 	}, [currDataset, latestFrozenVersionNum, skip, limit]);
 
 	const handleVersionChange = (selectedDatasetId: string) => {
-		localStorage.setItem("currVersionPageNum", currVersionPageNum.toString());
-		history(`/datasets/${selectedDatasetId}`);
+		// current version flip to page 1
+		if (selectedDatasetId === currDataset.origin_id) {
+			history(`/datasets/${selectedDatasetId}?currVersionPageNum=1`);
+			// other version flip to the current page
+		} else {
+			history(
+				`/datasets/${selectedDatasetId}?currVersionPageNum=${currVersionPageNum}`
+			);
+		}
 	};
 
 	const handlePageChange = (_: ChangeEvent<unknown>, value: number) => {

--- a/frontend/src/components/datasets/DatasetVersions.tsx
+++ b/frontend/src/components/datasets/DatasetVersions.tsx
@@ -11,7 +11,6 @@ import { theme } from "../../theme";
 export const DatasetVersions = (props) => {
 	const { currDataset, setSnackBarMessage, setSnackBarOpen } = props;
 	const dispatch = useDispatch();
-	const [selectedId, setSelectedId] = useState(currDataset.id);
 	const [currPageNum, setCurrPageNum] = useState<number>(1);
 	const [limit] = useState<number>(config.defaultVersionPerPage);
 
@@ -34,7 +33,6 @@ export const DatasetVersions = (props) => {
 	const history = useNavigate();
 
 	useEffect(() => {
-		// TODO implement proper pagination
 		let datasetId;
 		if (currDataset.origin_id) datasetId = currDataset.origin_id;
 		else datasetId = currDataset.id;
@@ -45,10 +43,9 @@ export const DatasetVersions = (props) => {
 		selectedDatasetId: string,
 		selectedVersionNum: string
 	) => {
-		setSelectedId(selectedDatasetId);
-		history(`/datasets/${selectedDatasetId}`);
 		setSnackBarMessage(`Viewing dataset version ${selectedVersionNum}.`);
 		setSnackBarOpen(true);
+		history(`/datasets/${selectedDatasetId}`);
 	};
 
 	const handlePageChange = (_: ChangeEvent<unknown>, value: number) => {
@@ -72,14 +69,14 @@ export const DatasetVersions = (props) => {
 						}}
 						sx={{
 							color:
-								selectedId === currDataset.origin_id
+								currDataset.id === currDataset.origin_id
 									? theme.palette.info.main
 									: theme.palette.primary.main,
 							pointerEvents:
-								selectedId === currDataset.origin_id ? "none" : "auto",
+								currDataset.id === currDataset.origin_id ? "none" : "auto",
 							textDecoration: "none",
 							fontWeight:
-								selectedId === currDataset.origin_id ? "bold" : "normal",
+								currDataset.id === currDataset.origin_id ? "bold" : "normal",
 							"&:hover": {
 								textDecoration: "underline",
 							},
@@ -97,12 +94,12 @@ export const DatasetVersions = (props) => {
 							}}
 							sx={{
 								color:
-									selectedId === dataset.id
+									currDataset.id === dataset.id
 										? theme.palette.info.main
 										: theme.palette.primary.main,
-								pointerEvents: selectedId === dataset.id ? "none" : "auto",
+								pointerEvents: currDataset.id === dataset.id ? "none" : "auto",
 								textDecoration: "none",
-								fontWeight: selectedId === dataset.id ? "bold" : "normal",
+								fontWeight: currDataset.id === dataset.id ? "bold" : "normal",
 								"&:hover": {
 									textDecoration: "underline",
 								},

--- a/frontend/src/components/datasets/PublicDataset.tsx
+++ b/frontend/src/components/datasets/PublicDataset.tsx
@@ -131,6 +131,14 @@ export const PublicDataset = (): JSX.Element => {
 	useEffect(() => {
 		if (dataset && dataset.license_id !== undefined)
 			fetchStandardLicenseUrlData(dataset.license_id);
+		setSnackBarOpen(true);
+		setSnackBarMessage(
+			`Viewing dataset version ${
+				dataset.id === dataset.origin_id
+					? "current unreleased"
+					: dataset.frozen_version_num
+			}.`
+		);
 	}, [dataset]);
 
 	// for breadcrumb
@@ -308,11 +316,7 @@ export const PublicDataset = (): JSX.Element => {
 					</TabPanel>
 				</Grid>
 				<Grid item xs={12} sm={12} md={2} lg={2} xl={2}>
-					<PublicDatasetVersions
-						currDataset={dataset}
-						setSnackBarMessage={setSnackBarMessage}
-						setSnackBarOpen={setSnackBarOpen}
-					/>
+					<PublicDatasetVersions currDataset={dataset} />
 					<Typography variant="h5" gutterBottom>
 						License
 					</Typography>

--- a/frontend/src/components/datasets/PublicDatasetVersions.tsx
+++ b/frontend/src/components/datasets/PublicDatasetVersions.tsx
@@ -1,13 +1,23 @@
-import { Box, FormControl, MenuItem, Typography } from "@mui/material";
-import { ClowderSelect } from "../styledComponents/ClowderSelect";
-import React, { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Box, Link, Pagination, Typography } from "@mui/material";
+import React, { ChangeEvent, useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { getPublicFreezeDatasets as getPublicFreezeDatasetsAction } from "../../actions/public_dataset";
 import { RootState } from "../../types/data";
+import config from "../../app.config";
+import { theme } from "../../theme";
+import { parseDate } from "../../utils/common";
 
 export const PublicDatasetVersions = (props) => {
-	const { currDataset, setSnackBarMessage, setSnackBarOpen } = props;
+	// search parameters
+	const [searchParams] = useSearchParams();
+	const currVersionPageNumParam = searchParams.get("currVersionPageNum");
+
+	const { currDataset } = props;
+
+	const [currVersionPageNum, setCurrVersionPageNum] = useState<number>(1);
+	const [limit] = useState<number>(config.defaultVersionPerPage);
+	const [skip, setSkip] = useState<number>(0);
 
 	const dispatch = useDispatch();
 	const getPublicFreezeDatasets = (
@@ -19,70 +29,122 @@ export const PublicDatasetVersions = (props) => {
 	const frozenDatasets = useSelector(
 		(state: RootState) => state.publicDataset.publicFrozenDatasets.data
 	);
+	const pageMetadata = useSelector(
+		(state: RootState) => state.publicDataset.publicFrozenDatasets.metadata
+	);
 
 	const history = useNavigate();
 
 	useEffect(() => {
-		// TODO implement proper pagination
+		if (currVersionPageNumParam) {
+			const pageNum = parseInt(currVersionPageNumParam, 10);
+			setCurrVersionPageNum(pageNum);
+			setSkip((pageNum - 1) * limit);
+		}
+	}, [currVersionPageNumParam]);
+
+	useEffect(() => {
 		let datasetId;
 		if (currDataset.origin_id) datasetId = currDataset.origin_id;
 		else datasetId = currDataset.id;
-		if (datasetId) getPublicFreezeDatasets(datasetId, 0, 1000);
-	}, [currDataset]);
+		if (datasetId) getPublicFreezeDatasets(datasetId, skip, limit);
+	}, [currDataset, skip, limit]);
 
-	function handleVersionChange(event) {
-		if (event.target.value === "current") {
-			history(`/public/datasets/${currDataset.origin_id}`);
-			setSnackBarMessage(`Viewing current unreleased dataset.`);
-			setSnackBarOpen(true);
+	const handleVersionChange = (selectedDatasetId: string) => {
+		// current version flip to page 1
+		if (selectedDatasetId === currDataset.origin_id) {
+			history(`/public/datasets/${selectedDatasetId}?currVersionPageNum=1`);
+			// other version flip to the current page
 		} else {
-			const selectedDataset = frozenDatasets.find(
-				(dataset) => dataset.id === event.target.value
+			history(
+				`/public/datasets/${selectedDatasetId}?currVersionPageNum=${currVersionPageNum}`
 			);
-
-			if (selectedDataset) {
-				history(`/public/datasets/${selectedDataset.id}`);
-				setSnackBarMessage(
-					`Viewing dataset version ${selectedDataset.frozen_version_num}.`
-				);
-				setSnackBarOpen(true);
-			} else {
-				console.error("Selected dataset not found in the list");
-			}
 		}
-	}
+	};
+
+	const handlePageChange = (_: ChangeEvent<unknown>, value: number) => {
+		const originDatasetId = currDataset.origin_id;
+		const newSkip = (value - 1) * limit;
+		setCurrVersionPageNum(value);
+		setSkip(newSkip);
+		getPublicFreezeDatasets(originDatasetId, newSkip, limit);
+	};
 
 	return (
 		<Box sx={{ mt: 2, mb: 5 }}>
 			<Typography variant="h5" gutterBottom>
 				Dataset Version
 			</Typography>
-			<Typography>Select Version</Typography>
-			<FormControl>
-				<ClowderSelect
-					value={
-						currDataset &&
-						currDataset.frozen &&
-						currDataset.frozen_version_num > 0
-							? currDataset.id
-							: "current"
-					}
-					onChange={handleVersionChange}
-				>
-					<MenuItem value="current" key="current">
-						Current
-					</MenuItem>
-					{frozenDatasets && frozenDatasets.length > 0
-						? frozenDatasets.map((dataset) => {
-								return (
-									<MenuItem value={dataset.id} key={dataset.id}>
-										{`Version ${dataset.frozen_version_num}`}
-									</MenuItem>
-								);
-						  })
-						: null}
-				</ClowderSelect>
-			</FormControl>
+			<Box>
+				<Box key={currDataset.origin_id} mb={2}>
+					<Link
+						component="button"
+						onClick={() => {
+							handleVersionChange(currDataset.origin_id);
+						}}
+						sx={{
+							color:
+								currDataset.id === currDataset.origin_id
+									? theme.palette.info.main
+									: theme.palette.primary.main,
+							pointerEvents:
+								currDataset.id === currDataset.origin_id ? "none" : "auto",
+							textDecoration: "none",
+							fontWeight:
+								currDataset.id === currDataset.origin_id ? "bold" : "normal",
+							"&:hover": {
+								textDecoration: "underline",
+							},
+						}}
+					>
+						Current Unreleased
+					</Link>
+				</Box>
+				{frozenDatasets.map((dataset) => (
+					<Box key={dataset.id} mb={2}>
+						<Link
+							component="button"
+							onClick={() => {
+								handleVersionChange(dataset.id);
+							}}
+							sx={{
+								color:
+									currDataset.id === dataset.id
+										? theme.palette.info.main
+										: theme.palette.primary.main,
+								pointerEvents: currDataset.id === dataset.id ? "none" : "auto",
+								textDecoration: "none",
+								fontWeight: currDataset.id === dataset.id ? "bold" : "normal",
+								"&:hover": {
+									textDecoration: "underline",
+								},
+							}}
+						>
+							Version {dataset.frozen_version_num}
+						</Link>
+						<Box>
+							<Typography
+								variant="caption"
+								sx={{ color: "text.primary.light" }}
+							>
+								{parseDate(dataset.modified)}
+							</Typography>
+						</Box>
+					</Box>
+				))}
+			</Box>
+			{frozenDatasets && frozenDatasets.length !== 0 ? (
+				<Box display="flex" justifyContent="center" sx={{ m: 1 }}>
+					<Pagination
+						count={Math.ceil(pageMetadata.total_count / limit)}
+						page={currVersionPageNum}
+						onChange={handlePageChange}
+						shape="circular"
+					/>
+				</Box>
+			) : (
+				<></>
+			)}
 		</Box>
 	);
 };

--- a/frontend/src/components/datasets/PublicDatasetVersions.tsx
+++ b/frontend/src/components/datasets/PublicDatasetVersions.tsx
@@ -16,9 +16,6 @@ export const PublicDatasetVersions = (props) => {
 		limit: number
 	) => dispatch(getPublicFreezeDatasetsAction(datasetId, skip, limit));
 
-	const pageMetadata = useSelector(
-		(state: RootState) => state.publicDataset.publicFrozenDatasets.metadata
-	);
 	const frozenDatasets = useSelector(
 		(state: RootState) => state.publicDataset.publicFrozenDatasets.data
 	);

--- a/frontend/src/components/versions/FeezeVersionChip.tsx
+++ b/frontend/src/components/versions/FeezeVersionChip.tsx
@@ -19,11 +19,7 @@ export function FreezeVersionChip(props: FreezeVersionChipProps) {
 					</Tooltip>
 				</Box>
 			) : (
-				<Box sx={{ display: "flex", alignItems: "end" }}>
-					<Tooltip title="This is a current draft.">
-						<ClowderVersionPill>Now</ClowderVersionPill>
-					</Tooltip>
-				</Box>
+				<></>
 			)}
 		</>
 	);


### PR DESCRIPTION
Ready to be reviewed.
This PR:
- Allow pagination to all the dataset versions
- Use query parameter currVersionPageNum={} to record which current version and page it is on; so after hard reload it will still point to the correct place

<img width="1789" alt="image" src="https://github.com/clowder-framework/clowder2/assets/13950475/300b2c67-8aae-4408-bf8e-c9eabf6ac3d7">

