### PR TITLE
978 migrate users

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -33,7 +33,6 @@ pytest = "7.3.1"
 pytest-asyncio = "0.21.0"
 black = "23.3.0"
 faker = "18.4.0"
-python-dotenv = "1.0.1"
 
 [requires]
 python_version = "3.9"

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -33,6 +33,7 @@ pytest = "7.3.1"
 pytest-asyncio = "0.21.0"
 black = "23.3.0"
 faker = "18.4.0"
+python-dotenv = "1.0.1"
 
 [requires]
 python_version = "3.9"

--- a/backend/app/keycloak_auth.py
+++ b/backend/app/keycloak_auth.py
@@ -312,7 +312,7 @@ async def get_current_user_id(identity: Json = Depends(get_token)) -> str:
     return keycloak_id
 
 
-async def create_user(email: str, password: str, firstName: str, lastName: str):
+async def create_user(email: str, password: str, firstName: str, lastName: str, temporary=False):
     """Create a user in Keycloak."""
     keycloak_admin = KeycloakAdmin(
         server_url=settings.auth_server_url,
@@ -336,6 +336,7 @@ async def create_user(email: str, password: str, firstName: str, lastName: str):
                 {
                     "value": password,
                     "type": "password",
+                    "temporary": temporary,
                 }
             ],
         },

--- a/backend/app/keycloak_auth.py
+++ b/backend/app/keycloak_auth.py
@@ -312,7 +312,7 @@ async def get_current_user_id(identity: Json = Depends(get_token)) -> str:
     return keycloak_id
 
 
-async def create_user(email: str, password: str, firstName: str, lastName: str, temporary=False):
+async def create_user(email: str, password: str, firstName: str, lastName: str):
     """Create a user in Keycloak."""
     keycloak_admin = KeycloakAdmin(
         server_url=settings.auth_server_url,
@@ -336,7 +336,6 @@ async def create_user(email: str, password: str, firstName: str, lastName: str, 
                 {
                     "value": password,
                     "type": "password",
-                    "temporary": temporary,
                 }
             ],
         },

--- a/backend/app/keycloak_auth.py
+++ b/backend/app/keycloak_auth.py
@@ -312,7 +312,7 @@ async def get_current_user_id(identity: Json = Depends(get_token)) -> str:
     return keycloak_id
 
 
-async def create_user(email: str, password: str, firstName: str, lastName: str):
+async def create_user(email: str, password: str, firstName: str, lastName: str, temporary: bool = False):
     """Create a user in Keycloak."""
     keycloak_admin = KeycloakAdmin(
         server_url=settings.auth_server_url,
@@ -336,6 +336,7 @@ async def create_user(email: str, password: str, firstName: str, lastName: str):
                 {
                     "value": password,
                     "type": "password",
+                    "temporary": temporary,
                 }
             ],
         },

--- a/scripts/migration/migrate_metadata_definitions.py
+++ b/scripts/migration/migrate_metadata_definitions.py
@@ -1,0 +1,34 @@
+import os
+from faker import Faker
+from dotenv import dotenv_values, load_dotenv
+import requests
+
+fake = Faker()
+
+path_to_env = os.path.join(os.getcwd(), 'scripts', 'migration', '.env')
+print(os.path.isfile(path_to_env))
+config = dotenv_values(dotenv_path=path_to_env)
+
+CLOWDER_V1 = config["CLOWDER_V1"]
+ADMIN_KEY_V1 = config["ADMIN_KEY_V1"]
+
+CLOWDER_V2 = config["CLOWDER_V2"]
+ADMIN_KEY_V2 = config["ADMIN_KEY_V2"]
+
+base_headers_v1 = {'X-API-key': ADMIN_KEY_V1}
+clowder_headers_v1 = {**base_headers_v1, 'Content-type': 'application/json',
+        'accept': 'application/json'}
+
+base_headers_v2 = {'X-API-key': ADMIN_KEY_V2}
+clowder_headers_v2 = {**base_headers_v2, 'Content-type': 'application/json',
+        'accept': 'application/json'}
+
+
+def get_clowder_v1_metadata_definitions():
+    endpoint = CLOWDER_V1 + 'api/metadata/definitions'
+    r = requests.get(endpoint, headers=base_headers_v1, verify=False)
+    return r.json()
+
+
+md_definitions = get_clowder_v1_metadata_definitions()
+print('got them')

--- a/scripts/migration/migrate_users.py
+++ b/scripts/migration/migrate_users.py
@@ -1,0 +1,65 @@
+import os
+from faker import Faker
+from dotenv import dotenv_values, load_dotenv
+import requests
+
+fake = Faker()
+
+path_to_env = os.path.join(os.getcwd(), 'scripts', 'migration', '.env')
+print(os.path.isfile(path_to_env))
+config = dotenv_values(dotenv_path=path_to_env)
+
+CLOWDER_V1 = config["CLOWDER_V1"]
+ADMIN_KEY_V1 = config["ADMIN_KEY_V1"]
+
+CLOWDER_V2 = config["CLOWDER_V2"]
+ADMIN_KEY_V2 = config["ADMIN_KEY_V2"]
+
+base_headers_v1 = {'X-API-key': ADMIN_KEY_V1}
+clowder_headers_v1 = {**base_headers_v1, 'Content-type': 'application/json',
+        'accept': 'application/json'}
+
+base_headers_v2 = {'X-API-key': ADMIN_KEY_V2}
+clowder_headers_v2 = {**base_headers_v2, 'Content-type': 'application/json',
+        'accept': 'application/json'}
+
+def email_user_new_login(user):
+    print("login to the new clowder instance")
+
+def generate_user_api_key(user):
+    print("Generate user api key")
+
+def get_clowder_v1_users():
+    endpoint = CLOWDER_V1 + 'api/users'
+    r = requests.get(endpoint,  headers=base_headers_v1, verify=False)
+    return r.json()
+
+def create_local_user(local_user_v1):
+    first_name = user_v1['firstName']
+    last_name = user_v1['lastName']
+    email = user_v1['email']
+    password = fake.password(20)
+    user_json = {
+        "email": email,
+        "password": password,
+        "first_name": first_name,
+        "last_name": last_name
+    }
+    response = requests.post(f"{CLOWDER_V2}api/v2/users", json=user_json)
+    email_user_new_login(user_json)
+    api_key = generate_user_api_key(user_json)
+    print("Local user created and api key generated")
+    return api_key
+
+users_v1 = get_clowder_v1_users()
+
+
+for user_v1 in users_v1:
+    print(user_v1)
+    id_provider = user_v1['identityProvider']
+    if '[Local Account]' in user_v1['identityProvider']:
+        new_user_api_key = generate_user_api_key(user_v1)
+    else:
+        print("not a local account")
+
+

--- a/scripts/migration/migrate_users.py
+++ b/scripts/migration/migrate_users.py
@@ -2,9 +2,44 @@ import os
 from faker import Faker
 from dotenv import dotenv_values, load_dotenv
 import requests
+import asyncio
 from pymongo import MongoClient
+from app.config import settings
+from itsdangerous.url_safe import URLSafeSerializer
+from secrets import token_urlsafe
+from app.routers.files import add_file_entry
+from app.models.files import (
+    FileOut,
+    FileDB,
+    FileDBViewList,
+    LocalFileIn,
+    StorageType,
+)
+from app.models.users import UserDB, UserOut, UserAPIKeyDB
+from beanie import init_beanie
+from fastapi import FastAPI, APIRouter, Depends
+from motor.motor_asyncio import AsyncIOMotorClient
 
+app = FastAPI()
+@app.on_event("startup")
+async def start_db():
+    client = AsyncIOMotorClient(str(settings.MONGODB_URL))
+    await init_beanie(
+        database=getattr(client, settings.MONGO_DATABASE),
+        # Make sure to include all models. If one depends on another that is not in the list it is not clear which one is missing.
+        document_models=[
+            FileDB,
+            FileDBViewList,
+            UserDB,
+            UserAPIKeyDB,
+        ],
+        recreate_views=True,
+    )
+
+
+asyncio.run(start_db())
 output_file = 'new_users.txt'
+
 
 fake = Faker()
 
@@ -39,7 +74,11 @@ def email_user_new_login(user):
     print("login to the new clowder instance")
 
 def generate_user_api_key(user):
-    print("Generate user api key")
+    serializer = URLSafeSerializer(settings.local_auth_secret, salt="api_key")
+    unique_key = token_urlsafe(16)
+    hashed_key = serializer.dumps({"user": user, "key": unique_key})
+    user_key = UserAPIKeyDB(user=user, key=unique_key, name='migrationKey')
+    return user_key.key
 
 def get_clowder_v1_users():
     endpoint = CLOWDER_V1 + 'api/users'
@@ -51,14 +90,32 @@ def get_clowder_v2_users():
     r = requests.get(endpoint, headers=base_headers_v1, verify=False)
     return r.json()
 
-def create_v2_dataset(headers, dataset):
+async def create_v2_dataset(headers, dataset, user_email):
     print(dataset)
+    dataset_name = dataset['name']
+    dataset_description = dataset['description']
     dataset_endpoint = CLOWDER_V1 + 'api/datasets/' + dataset['id']
     r = requests.get(dataset_endpoint, headers=base_headers_v1, verify=False)
-    dataset_result = r.json()
     dataset_files_endpoint = CLOWDER_V1 + 'api/datasets/' + dataset['id'] + '/files'
     r_files = requests.get(dataset_files_endpoint, headers=base_headers_v1, verify=False)
+    dataset_in_v2_endpoint = CLOWDER_V2 + 'api/v2/datasets'
+    # create dataset
+    dataset_example = {
+        "name": dataset_name,
+        "description": dataset_description,
+    }
+    response = requests.post(
+        dataset_in_v2_endpoint, headers=headers, json=dataset_example
+    )
     files_result = r_files.json()
+    if (user := await UserDB.find_one(UserDB.email == user_email)) is not None:
+        print('we got a user!')
+    for file in files_result:
+        new_file = FileDB(
+            name=file['filename'],
+            creator=user,
+            dataset_id=dataset.id,
+        )
     print('here')
 
 
@@ -72,7 +129,7 @@ def get_clowder_v1_user_datasets(user_id):
             user_datasets.append(dataset)
     return user_datasets
 
-def create_local_user(local_user_v1):
+def create_local_user(user_v1):
     first_name = user_v1['firstName']
     last_name = user_v1['lastName']
     email = user_v1['email']
@@ -84,40 +141,51 @@ def create_local_user(local_user_v1):
         "first_name": first_name,
         "last_name": last_name
     }
-    response = requests.post(f"{CLOWDER_V2}api/v2/users", json=user_json)
-    email_user_new_login(user_json)
-    api_key = generate_user_api_key(user_json)
+    # response = requests.post(f"{CLOWDER_V2}api/v2/users", json=user_json)
+    email_user_new_login(email)
+    api_key = generate_user_api_key(email)
     print("Local user created and api key generated")
+    if os.path.exists(output_file):
+        print('it exists.')
+    else:
+        f = open(output_file, "x")
     with open(output_file, 'a') as f:
         entry = email + ',' + password + ',' + api_key + "\n"
         f.write(entry)
     return api_key
 
-users_v1 = get_clowder_v1_users()
+async def process_users():
+    users_v1 = get_clowder_v1_users()
 
+    for user_v1 in users_v1:
+        print(user_v1)
+        id = user_v1['id']
+        email = user_v1['email']
+        firstName = user_v1['firstName']
+        lastName = user_v1['lastName']
 
-for user_v1 in users_v1:
-    print(user_v1)
-    id = user_v1['id']
-    email = user_v1['email']
-    firstName = user_v1['firstName']
-    lastName = user_v1['lastName']
+        id_provider = user_v1['identityProvider']
+        if '[Local Account]' in user_v1['identityProvider']:
+            # get the v2 users
+            if email != "a@a.com":
+                user_v1_datasets = get_clowder_v1_user_datasets(user_id=id)
+                # TODO check if there is already a local user
+                # user_v2_api_key = create_local_user(user_v1)
+                user_v2_api_key = 'aZM2QXJ_lvw_5FKNUB89Vg'
+                user_base_headers_v2 = {'X-API-key': user_v2_api_key}
+                user_headers_v2 = {**user_base_headers_v2, 'Content-type': 'application/json',
+                                      'accept': 'application/json'}
+                for dataset in user_v1_datasets:
+                    print('creating a dataset in v2')
+                    dataset_id = await create_v2_dataset(user_headers_v2, dataset, email)
+                    dataset_files_endpoint = CLOWDER_V1 + 'api/datasets/' + dataset['id'] + '/files'
+                    r_files = requests.get(dataset_files_endpoint, headers=base_headers_v1, verify=False)
+                    r_files_json = r_files.json()
+                    print('here')
 
-    id_provider = user_v1['identityProvider']
-    if '[Local Account]' in user_v1['identityProvider']:
-        # get the v2 users
-        if email != "a@a.com":
-            user_v1_datasets = get_clowder_v1_user_datasets(user_id=id)
-            # user_v2_api_key = create_local_user(user_v1)
-            # user_base_headers_v2 = {'X-API-key': user_v2_api_key}
-            # user_headers_v2 = {**user_base_headers_v2, 'Content-type': 'application/json',
-            #                       'accept': 'application/json'}
-            for dataset in user_v1_datasets:
-                print('creating a dataset in v2')
-                dataset_id = create_v2_dataset("user_headers_v2", dataset)
+        else:
+            print("not a local account")
 
-
-    else:
-        print("not a local account")
+asyncio.run(process_users())
 
 

--- a/scripts/migration/migrate_users.py
+++ b/scripts/migration/migrate_users.py
@@ -2,6 +2,9 @@ import os
 from faker import Faker
 from dotenv import dotenv_values, load_dotenv
 import requests
+from pymongo import MongoClient
+
+output_file = 'new_users.txt'
 
 fake = Faker()
 
@@ -23,6 +26,15 @@ base_headers_v2 = {'X-API-key': ADMIN_KEY_V2}
 clowder_headers_v2 = {**base_headers_v2, 'Content-type': 'application/json',
         'accept': 'application/json'}
 
+TEST_DATASET_NAME = 'Migration Test Dataset'
+# TODO this is just for testing
+DEFAULT_PASSWORD = 'Password123&'
+mongo_client = MongoClient("mongodb://localhost:27018", connect=False)
+db = mongo_client["clowder"]
+print('got the db')
+v1_users = db["social.users"].find({})
+for u in v1_users:
+    print(u)
 def email_user_new_login(user):
     print("login to the new clowder instance")
 
@@ -33,6 +45,32 @@ def get_clowder_v1_users():
     endpoint = CLOWDER_V1 + 'api/users'
     r = requests.get(endpoint,  headers=base_headers_v1, verify=False)
     return r.json()
+
+def get_clowder_v2_users():
+    endpoint = CLOWDER_V2 + 'api/v2/users'
+    r = requests.get(endpoint, headers=base_headers_v1, verify=False)
+    return r.json()
+
+def create_v2_dataset(headers, dataset):
+    print(dataset)
+    dataset_endpoint = CLOWDER_V1 + 'api/datasets/' + dataset['id']
+    r = requests.get(dataset_endpoint, headers=base_headers_v1, verify=False)
+    dataset_result = r.json()
+    dataset_files_endpoint = CLOWDER_V1 + 'api/datasets/' + dataset['id'] + '/files'
+    r_files = requests.get(dataset_files_endpoint, headers=base_headers_v1, verify=False)
+    files_result = r_files.json()
+    print('here')
+
+
+def get_clowder_v1_user_datasets(user_id):
+    user_datasets = []
+    endpoint = CLOWDER_V1 + 'api/datasets?limit=0'
+    r = requests.get(endpoint, headers=base_headers_v1, verify=False)
+    request_json = r.json()
+    for dataset in request_json:
+        if dataset['authorId'] == user_id:
+            user_datasets.append(dataset)
+    return user_datasets
 
 def create_local_user(local_user_v1):
     first_name = user_v1['firstName']
@@ -50,6 +88,9 @@ def create_local_user(local_user_v1):
     email_user_new_login(user_json)
     api_key = generate_user_api_key(user_json)
     print("Local user created and api key generated")
+    with open(output_file, 'a') as f:
+        entry = email + ',' + password + ',' + api_key + "\n"
+        f.write(entry)
     return api_key
 
 users_v1 = get_clowder_v1_users()
@@ -57,13 +98,25 @@ users_v1 = get_clowder_v1_users()
 
 for user_v1 in users_v1:
     print(user_v1)
+    id = user_v1['id']
     email = user_v1['email']
     firstName = user_v1['firstName']
     lastName = user_v1['lastName']
 
     id_provider = user_v1['identityProvider']
     if '[Local Account]' in user_v1['identityProvider']:
-        user_v2 = create_local_user(user_v1)
+        # get the v2 users
+        if email != "a@a.com":
+            user_v1_datasets = get_clowder_v1_user_datasets(user_id=id)
+            # user_v2_api_key = create_local_user(user_v1)
+            # user_base_headers_v2 = {'X-API-key': user_v2_api_key}
+            # user_headers_v2 = {**user_base_headers_v2, 'Content-type': 'application/json',
+            #                       'accept': 'application/json'}
+            for dataset in user_v1_datasets:
+                print('creating a dataset in v2')
+                dataset_id = create_v2_dataset("user_headers_v2", dataset)
+
+
     else:
         print("not a local account")
 

--- a/scripts/migration/migrate_users.py
+++ b/scripts/migration/migrate_users.py
@@ -38,7 +38,8 @@ def create_local_user(local_user_v1):
     first_name = user_v1['firstName']
     last_name = user_v1['lastName']
     email = user_v1['email']
-    password = fake.password(20)
+    # password = fake.password(20)
+    password = 'Password123&'
     user_json = {
         "email": email,
         "password": password,
@@ -56,9 +57,13 @@ users_v1 = get_clowder_v1_users()
 
 for user_v1 in users_v1:
     print(user_v1)
+    email = user_v1['email']
+    firstName = user_v1['firstName']
+    lastName = user_v1['lastName']
+
     id_provider = user_v1['identityProvider']
     if '[Local Account]' in user_v1['identityProvider']:
-        new_user_api_key = generate_user_api_key(user_v1)
+        user_v2 = create_local_user(user_v1)
     else:
         print("not a local account")
 


### PR DESCRIPTION
This is a draft pull request for now. Here we will migrate users from a clowder v1 instance into a clowder v2 instance. Currently this works for users, datasets, and files inside datasets. 

Next I will be working on folders and metadata. 

A later pull request will address collection hierarchies, CILogon accounts, and other features outside of the scope of this one.

To test this, you will want to run a clowder v1 instance. Since both need to run a different version of MongoDB, change this in the .yml file for the dependencies in v1.

```
  # database to hold metadata (required)
  mongo:
    image: mongo:3.6
    restart: unless-stopped
    networks:
      - clowder
    command: mongod --port 27018
    ports:
      - '27018:27018'
    volumes:
      - mongo:/data/db
```

also change this in application.conf

`mongodbURI = "mongodb://127.0.0.1:27018/clowder"`

If you add entries to the v1 instance, try migrating them.
