### PR TITLE
read only user can be made admin

### DIFF
--- a/frontend/src/components/users/ManageUsers.tsx
+++ b/frontend/src/components/users/ManageUsers.tsx
@@ -157,7 +157,7 @@ export const ManageUsers = (): JSX.Element => {
 																setAdmin(profile.email);
 															}
 														}}
-														disabled={profile.email === currentUser.email || currentUser.read_only_user}
+														disabled={profile.email === currentUser.email || profile.read_only_user}
 													/>
 												</TableCell>
 												<TableCell align="left">


### PR DESCRIPTION
The wrong condition was checked. Now once you user is made Read Only, the switch for Admin is not active in Manage Users.

Currently manage users is available to admins without being in super Admin mode. Please let me know if people think this should be changed. 