### PR TITLE
fix elasticsearch delete GH action

### DIFF
--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -356,6 +356,7 @@ async def download_file_url(
     file_id: str,
     version: Optional[int] = None,
     expires_in_seconds: Optional[int] = 3600,
+    increment: Optional[bool] = True,
     es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
     external_fs: Minio = Depends(dependencies.get_external_fs),
     allow: bool = Depends(FileAuthorization("viewer")),
@@ -395,14 +396,20 @@ async def download_file_url(
                 expires=expires,
             )
 
-        # Increment download count
-        await file.update(Inc({FileDB.downloads: 1}))
+        if presigned_url is not None:
+            if increment:
+                # Increment download count
+                await file.update(Inc({FileDB.downloads: 1}))
 
-        # reindex
-        await index_file(es, FileOut(**file.dict()), update=True)
+                # reindex
+                await index_file(es, FileOut(**file.dict()), update=True)
 
-        # return presigned url
-        return {"presigned_url": presigned_url}
+            # return presigned url
+            return {"presigned_url": presigned_url}
+        else:
+            raise HTTPException(
+                status_code=500, detail="Unable to generate presigned URL"
+            )
     else:
         raise HTTPException(status_code=404, detail=f"File {file_id} not found")
 

--- a/frontend/src/openapi/v2/services/FilesService.ts
+++ b/frontend/src/openapi/v2/services/FilesService.ts
@@ -93,6 +93,7 @@ export class FilesService {
      * @param fileId
      * @param version
      * @param expiresInSeconds
+     * @param increment
      * @param datasetId
      * @returns any Successful Response
      * @throws ApiError
@@ -101,6 +102,7 @@ export class FilesService {
         fileId: string,
         version?: number,
         expiresInSeconds: number = 3600,
+        increment: boolean = true,
         datasetId?: string,
     ): CancelablePromise<any> {
         return __request({
@@ -109,6 +111,7 @@ export class FilesService {
             query: {
                 'version': version,
                 'expires_in_seconds': expiresInSeconds,
+                'increment': increment,
                 'dataset_id': datasetId,
             },
             errors: {

--- a/openapi.json
+++ b/openapi.json
@@ -2826,6 +2826,16 @@
           {
             "required": false,
             "schema": {
+              "title": "Increment",
+              "type": "boolean",
+              "default": true
+            },
+            "name": "increment",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
               "title": "Dataset Id",
               "type": "string"
             },


### PR DESCRIPTION
When I switch delete by query `es_client.delete_by_query(index=index_name, query=query)` to delete by id `es_client.delete(index=index_name, id=id)`, it somehow worked.

I'm still not sure why it has multiple "versions" and complain about that in the first place. 