### PR TITLE
Removed snackbar message on clearing metadata form

### DIFF
--- a/frontend/src/components/metadata/CreateMetadataDefinition.tsx
+++ b/frontend/src/components/metadata/CreateMetadataDefinition.tsx
@@ -36,18 +36,12 @@ interface SupportedInputs {
 
 type CreateMetadataDefinitionProps = {
 	setCreateMetadataDefinitionOpen: any;
-	setSnackBarOpen: any;
-	setSnackBarMessage: any;
 };
 
 export const CreateMetadataDefinition = (
 	props: CreateMetadataDefinitionProps
 ) => {
-	const {
-		setCreateMetadataDefinitionOpen,
-		setSnackBarOpen,
-		setSnackBarMessage,
-	} = props;
+	const { setCreateMetadataDefinitionOpen } = props;
 
 	const dispatch = useDispatch();
 	const history = useNavigate();
@@ -334,9 +328,6 @@ export const CreateMetadataDefinition = (
 		});
 
 		setContextMap([{ term: "", iri: "" }]);
-		// TODO add snackbar here
-		setSnackBarMessage("Successfully added metadata definition");
-		setSnackBarOpen(true);
 	};
 
 	const handleNext = () => {

--- a/frontend/src/components/metadata/MetadataDefinitions.tsx
+++ b/frontend/src/components/metadata/MetadataDefinitions.tsx
@@ -148,8 +148,6 @@ export function MetadataDefinitions() {
 				<DialogContent>
 					<CreateMetadataDefinition
 						setCreateMetadataDefinitionOpen={setCreateMetadataDefinitionOpen}
-						setSnackBarOpen={setSnackBarOpen}
-						setSnackBarMessage={setSnackBarMessage}
 					/>
 				</DialogContent>
 			</Dialog>


### PR DESCRIPTION
Try create a metadata definition. In last step, click on 'Clear' the form instead of submit, you should no longer see any snackbar. 

I have also removed the snackbar on successfully creating a definition. Since it takes you to the newly created metadata defn page, the user can't really see the snackbar and I don't see the use of the snackbar there.