### PR TITLE
allow use of external s3 store instead of minio

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -35,6 +35,8 @@ class Settings(BaseSettings):
     MINIO_UPLOAD_CHUNK_SIZE: int = 10 * 1024 * 1024
     MINIO_EXPIRES: int = 3600  # seconds
     MINIO_SECURE: str = "False"  # http vs https
+    MINIO_EXTERNAL_SECURE: str = "False"  # http vs https
+    MINIO_VERSIONING_ENABLED: str = "True"
 
     # Files in the listed directories can be added to Clowder without copying them elsewhere
     LOCAL_WHITELIST: List[str] = []

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -14,12 +14,13 @@ async def get_fs() -> Generator:
         settings.MINIO_SERVER_URL,
         access_key=settings.MINIO_ACCESS_KEY,
         secret_key=settings.MINIO_SECRET_KEY,
-        secure=False,
+        secure=settings.MINIO_SECURE.lower() == "true",
     )
     clowder_bucket = settings.MINIO_BUCKET_NAME
     if not file_system.bucket_exists(clowder_bucket):
         file_system.make_bucket(clowder_bucket)
-    file_system.set_bucket_versioning(clowder_bucket, VersioningConfig(ENABLED))
+    if settings.MINIO_VERSIONING_ENABLED.lower() == "true":
+        file_system.set_bucket_versioning(clowder_bucket, VersioningConfig(ENABLED))
     yield file_system
 
 
@@ -29,12 +30,13 @@ async def get_external_fs() -> Generator:
         settings.MINIO_EXTERNAL_SERVER_URL,
         access_key=settings.MINIO_ACCESS_KEY,
         secret_key=settings.MINIO_SECRET_KEY,
-        secure=settings.MINIO_SECURE.lower() == "true",
+        secure=settings.MINIO_EXTERNAL_SECURE.lower() == "true",
     )
     clowder_bucket = settings.MINIO_BUCKET_NAME
     if not file_system.bucket_exists(clowder_bucket):
         file_system.make_bucket(clowder_bucket)
-    file_system.set_bucket_versioning(clowder_bucket, VersioningConfig(ENABLED))
+    if settings.MINIO_VERSIONING_ENABLED.lower() == "true":
+        file_system.set_bucket_versioning(clowder_bucket, VersioningConfig(ENABLED))
     yield file_system
 
 

--- a/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
@@ -39,14 +39,18 @@ spec:
             - name: WEB_CONCURRENCY
               value: "1"
             - name: MINIO_SERVER_URL
-              value: {{ include "clowder2.name" . }}-minio:9000
+              value: {{ (empty .Values.minio.serverUrl) | ternary (printf "%s-minio:9000" (include "clowder2.name" .)) .Values.minio.serverUrl }}
 #              value: {{ include "clowder2.name" . }}-minio-headless:9000
             - name: MINIO_EXTERNAL_SERVER_URL
-              value: minio-api.{{ .Values.hostname }}
-            - name: MINIO_SECURE
+              value: {{ (empty .Values.minio.serverUrl) | ternary (printf "minio-api.%s" .Values.hostname) .Values.minio.serverUrl }}
+            - name: MINIO_EXTERNAL_SECURE
               value: "true"
+            - name: MINIO_SECURE
+              value: "{{ .Values.minio.auth.secure }}"
             - name: MINIO_BUCKET_NAME
               value: clowder
+            - name: MINIO_VERSIONING_ENABLED
+              value: "{{ .Values.minio.enableVersioning }}"
             - name: MINIO_ACCESS_KEY
               value: {{ .Values.minio.auth.rootUser }}
             - name: MINIO_SECRET_KEY

--- a/deployments/kubernetes/charts/clowder2/values.yaml
+++ b/deployments/kubernetes/charts/clowder2/values.yaml
@@ -81,15 +81,23 @@ geoserver:
 # MINIO
 # ----------------------------------------------------------------------
 minio:
+  # disable if using an external e3 store
   enabled: true
+  # set serverUrl for external s3 store
+  # serverUrl: my.s3.store.net
 
   # login to minio
   auth:
     rootUser: minioadmin
     rootPassword: minioadmin
+    # enable https/tls for external s3 store access
+    secure: false
 
   # enable webui
   disableWebUI: false
+
+  # disable for external s3 store without versioning support
+  enableVersioning: true
 
   containerPorts:
     api: 9000


### PR DESCRIPTION
Tested with openstack swift s3 api, which does not support versioning. Adds minio.serverUrl, minio.auth.secure, minio.enableVersioning values to helm chart values.yaml file.

To use with swift s3: set minio.enabled: false, set serverUrl to openstack s3 service endpoint, disable enableVersioning, and enable secure.