### PR TITLE
1080 enable search metadata

### DIFF
--- a/backend/app/models/search.py
+++ b/backend/app/models/search.py
@@ -44,4 +44,5 @@ class ElasticsearchEntry(BaseModel):
     bytes: Optional[int]
     # metadata fields
     metadata: Optional[List[dict]] = []
+    metadata_stringify: Optional[str]
     status: Optional[str]

--- a/backend/app/search/config.py
+++ b/backend/app/search/config.py
@@ -16,9 +16,11 @@ class IndexSettings:
             "dataset_id": {"type": "text", "index": False},
             "folder_id": {"type": "text", "index": False},
             "bytes": {"type": "long"},
-            # metadata fields
+            # metadata fields cast to plain string to enable search
             "metadata": {
                 "type": "object",
+                "dynamic": True,
+                "properties": {"*": {"type": "text"}},
             },
         }
     }

--- a/backend/app/search/config.py
+++ b/backend/app/search/config.py
@@ -16,12 +16,13 @@ class IndexSettings:
             "dataset_id": {"type": "text", "index": False},
             "folder_id": {"type": "text", "index": False},
             "bytes": {"type": "long"},
-            # metadata fields cast to plain string to enable search
+            # metadata fields
             "metadata": {
                 "type": "object",
                 "dynamic": True,
-                "properties": {"*": {"type": "text"}},
             },
+            # metadata fields cast to plain string to enable search
+            "metadata_stringify": {"type": "text"},
         }
     }
 

--- a/backend/app/search/index.py
+++ b/backend/app/search/index.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, Union
 
 from app.config import settings
@@ -51,6 +52,7 @@ async def index_dataset(
         downloads=dataset.downloads,
         user_ids=authorized_user_ids,
         metadata=metadata,
+        metadata_stringify=json.dumps(metadata),
         status=dataset_status,
     ).dict()
 
@@ -103,6 +105,7 @@ async def index_file(
         folder_id=str(file.folder_id),
         bytes=file.bytes,
         metadata=metadata,
+        metadata_stringify=json.dumps(metadata),
         status=file.status,
     ).dict()
     if update:
@@ -198,6 +201,7 @@ async def index_thumbnail(
                 folder_id=str(file.folder_id),
                 bytes=thumbnail.bytes,
                 metadata=metadata,
+                metadata_stringify=json.dumps(metadata),
                 downloads=thumbnail.downloads,
             ).dict()
             if update:

--- a/frontend/src/components/search/EmbeddedPublicSearch.tsx
+++ b/frontend/src/components/search/EmbeddedPublicSearch.tsx
@@ -46,7 +46,7 @@ export function EmbeddedPublicSearch() {
 				showFilter={true}
 				showClear
 				renderNoSuggestion="No suggestions found."
-				dataField={["name", "description"]}
+				dataField={["name", "description", "creator.keyword", "metadata"]}
 				// placeholder="Search for Dataset"
 				innerClass={{
 					title: "search-title",

--- a/frontend/src/components/search/EmbeddedPublicSearch.tsx
+++ b/frontend/src/components/search/EmbeddedPublicSearch.tsx
@@ -46,7 +46,13 @@ export function EmbeddedPublicSearch() {
 				showFilter={true}
 				showClear
 				renderNoSuggestion="No suggestions found."
-				dataField={["name", "description", "creator.keyword", "metadata"]}
+				dataField={[
+					"name",
+					"description",
+					"metadata_stringify",
+					"creator.keyword",
+				]}
+				fieldWeights={[3, 2, 2, 1]}
 				// placeholder="Search for Dataset"
 				innerClass={{
 					title: "search-title",

--- a/frontend/src/components/search/EmbeddedSearch.tsx
+++ b/frontend/src/components/search/EmbeddedSearch.tsx
@@ -46,7 +46,13 @@ export function EmbeddedSearch() {
 				showFilter={true}
 				showClear
 				renderNoSuggestion="No suggestions found."
-				dataField={["name", "description", "creator.keyword", "metadata"]}
+				dataField={[
+					"name",
+					"description",
+					"metadata_stringify",
+					"creator.keyword",
+				]}
+				fieldWeights={[3, 2, 2, 1]}
 				// placeholder="Search for Dataset"
 				innerClass={{
 					title: "search-title",

--- a/frontend/src/components/search/EmbeddedSearch.tsx
+++ b/frontend/src/components/search/EmbeddedSearch.tsx
@@ -46,7 +46,7 @@ export function EmbeddedSearch() {
 				showFilter={true}
 				showClear
 				renderNoSuggestion="No suggestions found."
-				dataField={["name", "description", "creator.keyword"]}
+				dataField={["name", "description", "creator.keyword", "metadata"]}
 				// placeholder="Search for Dataset"
 				innerClass={{
 					title: "search-title",

--- a/frontend/src/components/search/PublicSearch.tsx
+++ b/frontend/src/components/search/PublicSearch.tsx
@@ -98,10 +98,10 @@ export function PublicSearch() {
 										dataField={[
 											"name",
 											"description",
+											"metadata_stringify",
 											"creator.keyword",
-											"metadata",
 										]}
-										fieldWeights={[3, 2, 1]}
+										fieldWeights={[3, 2, 2, 1]}
 										innerClass={{
 											title: "search-title",
 											input: "search-input",

--- a/frontend/src/components/search/PublicSearch.tsx
+++ b/frontend/src/components/search/PublicSearch.tsx
@@ -95,7 +95,12 @@ export function PublicSearch() {
 										showFilter={true}
 										showClear={true}
 										renderNoSuggestion="No suggestions found."
-										dataField={["name", "description"]}
+										dataField={[
+											"name",
+											"description",
+											"creator.keyword",
+											"metadata",
+										]}
 										fieldWeights={[3, 2, 1]}
 										innerClass={{
 											title: "search-title",

--- a/frontend/src/components/search/Search.tsx
+++ b/frontend/src/components/search/Search.tsx
@@ -125,10 +125,10 @@ export function Search() {
 										dataField={[
 											"name",
 											"description",
+											"metadata_text",
 											"creator.keyword",
-											"metadata",
 										]}
-										fieldWeights={[3, 2, 1]}
+										fieldWeights={[3, 2, 2, 1]}
 										innerClass={{
 											title: "search-title",
 											input: "search-input",

--- a/frontend/src/components/search/Search.tsx
+++ b/frontend/src/components/search/Search.tsx
@@ -125,7 +125,7 @@ export function Search() {
 										dataField={[
 											"name",
 											"description",
-											"metadata_text",
+											"metadata_stringify",
 											"creator.keyword",
 										]}
 										fieldWeights={[3, 2, 2, 1]}

--- a/frontend/src/components/search/Search.tsx
+++ b/frontend/src/components/search/Search.tsx
@@ -122,7 +122,12 @@ export function Search() {
 										showFilter={true}
 										showClear={true}
 										renderNoSuggestion="No suggestions found."
-										dataField={["name", "description", "creator.keyword"]}
+										dataField={[
+											"name",
+											"description",
+											"creator.keyword",
+											"metadata",
+										]}
 										fieldWeights={[3, 2, 1]}
 										innerClass={{
 											title: "search-title",


### PR DESCRIPTION
Metadata is a dynamic field, making plain text keyword searches not possible. After experimenting with several approaches without success (detailed below), I have **added an additional field `metadata_stringify`** to convert the JSON into a string and cast it to text to enable keyword searches. The original `metadata` field ispreserved for advanced searches.

### To Test:

1. **Drop Volume**
2. **Create Metadata Definitions and Metadata:**
   - Examples: Abstract, LatLon, DateTime

3. **Keyword Search:**
   - Search by metadata key, e.g., "abstract", "latitude"
   - Search by metadata value, e.g., "your metadata value"
   - Test both the search bar on the top bar and the search page
   - Make sure public search functionality

4. **Advanced Search:**
   - Use correct syntax and field names
   - Examples:
     - `metadata.abstract:marker`
     - `metadata.latitude:[-70 TO -60]`
     - `metadata.longitude:[70 TO 90]`

### Screenshots:

![Screenshot1](https://github.com/clowder-framework/clowder2/assets/13950475/ad65301e-f34b-4d01-b8f2-e1ea71cf0e64)
![Screenshot2](https://github.com/clowder-framework/clowder2/assets/13950475/00639f74-735f-4c7d-b195-8ca9626cf35c)

---

### Things I Have Tried That Did Not Work:

1. **Updating the Mapping to Cast the Metadata Field to Text**
   ```json
   {
     "mappings": {
       "properties": {
         "metadata": {
           "type": "object",
           "dynamic": true,
           "properties": {
             "*": {
               "type": "text"
             }
           }
         }
       }
     }
   }
   ```

2. **Wildcard Search**
   ```bash
   curl -X GET "localhost:9200/clowder/_search" -H 'Content-Type: application/json' -d'
   {
     "query": {
       "query_string": {
         "query": "test search",
         "fields": ["metadata.*"]
       }
     }
   }
   '
   ```