### PR TITLE
removing left dividers

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,7 +6,6 @@ import Drawer from "@mui/material/Drawer";
 import MuiAppBar, { AppBarProps as MuiAppBarProps } from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import List from "@mui/material/List";
-import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import MenuIcon from "@mui/icons-material/Menu";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
@@ -273,7 +272,6 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemIcon>
 						<ListItemText>User Profile</ListItemText>
 					</MenuItem>
-					<Divider orientation="horizontal" />
 					{currUserProfile.admin ? (
 						<>
 							<MenuItem onClick={() => toggleAdminMode(!adminMode)}>
@@ -293,8 +291,6 @@ export default function PersistentDrawerLeft(props) {
 									</>
 								)}
 							</MenuItem>
-
-							<Divider orientation="horizontal" />
 						</>
 					) : (
 						<></>
@@ -306,7 +302,6 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemIcon>
 						<ListItemText>API Key</ListItemText>
 					</MenuItem>
-					<Divider orientation="horizontal" />
 					<MenuItem component={RouterLink} to="/auth/logout">
 						<ListItemIcon>
 							<LogoutIcon fontSize="small" />
@@ -338,7 +333,6 @@ export default function PersistentDrawerLeft(props) {
 						)}
 					</IconButton>
 				</DrawerHeader>
-				<Divider />
 				<List>
 					<ListItem key={"explore"} disablePadding>
 						<ListItemButton component={RouterLink} to="/">
@@ -349,7 +343,6 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemButton>
 					</ListItem>
 				</List>
-				<Divider />
 				<List>
 					<ListItem key={"search"} disablePadding>
 						<ListItemButton component={RouterLink} to="/search">
@@ -360,24 +353,21 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemButton>
 					</ListItem>
 				</List>
-				{currUserProfile.read_only_user ? <></> : <Divider />}
 				{currUserProfile.admin ? (
-					<>
-						<List>
-							<ListItem key={"manage-user"} disablePadding>
-								<ListItemButton component={RouterLink} to="/manage-users">
-									<ListItemIcon>
-										<ManageAccountsIcon />
-									</ListItemIcon>
-									<ListItemText primary={"Manage Users"} />
-								</ListItemButton>
-							</ListItem>
-						</List>
-						<Divider />
-					</>
+					<List>
+						<ListItem key={"manage-user"} disablePadding>
+							<ListItemButton component={RouterLink} to="/manage-users">
+								<ListItemIcon>
+									<ManageAccountsIcon />
+								</ListItemIcon>
+								<ListItemText primary={"Manage Users"} />
+							</ListItemButton>
+						</ListItem>
+					</List>
 				) : null}
-				<List>
-					{currUserProfile.read_only_user ? null : (
+
+				{currUserProfile.read_only_user ? null : (
+					<List>
 						<ListItem key={"groups"} disablePadding>
 							<ListItemButton component={RouterLink} to="/groups">
 								<ListItemIcon>
@@ -386,13 +376,12 @@ export default function PersistentDrawerLeft(props) {
 								<ListItemText primary={"Groups"} />
 							</ListItemButton>
 						</ListItem>
-					)}
-				</List>
-				{currUserProfile.read_only_user ? <></> : <Divider />}
-				<List>
-					{currUserProfile.read_only_user ? (
-						<></>
-					) : (
+					</List>
+				)}
+				{currUserProfile.read_only_user ? (
+					<></>
+				) : (
+					<List>
 						<ListItem key={"newdataset"} disablePadding>
 							<ListItemButton component={RouterLink} to="/create-dataset">
 								<ListItemIcon>
@@ -401,9 +390,8 @@ export default function PersistentDrawerLeft(props) {
 								<ListItemText primary={"New Dataset"} />
 							</ListItemButton>
 						</ListItem>
-					)}
-				</List>
-				<Divider />
+					</List>
+				)}
 				<List>
 					<ListItem key={"metadataDefinition"} disablePadding>
 						<ListItemButton component={RouterLink} to="/metadata-definitions">
@@ -414,7 +402,6 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemButton>
 					</ListItem>
 				</List>
-				<Divider />
 				<List>
 					<ListItem key={"extractions"} disablePadding>
 						<ListItemButton component={RouterLink} to="/extractions">
@@ -425,7 +412,6 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemButton>
 					</ListItem>
 				</List>
-				<Divider />
 				<List>
 					<ListItem key={"listeners"} disablePadding>
 						<ListItemButton component={RouterLink} to="/listeners">
@@ -436,7 +422,6 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemButton>
 					</ListItem>
 				</List>
-				<Divider />
 				<List>
 					<ListItem key={"feeds"} disablePadding>
 						<ListItemButton component={RouterLink} to="/feeds">

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -360,7 +360,7 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemButton>
 					</ListItem>
 				</List>
-				<Divider />
+				{currUserProfile.read_only_user ? <></> : <Divider />}
 				{currUserProfile.admin ? (
 					<>
 						<List>
@@ -377,9 +377,7 @@ export default function PersistentDrawerLeft(props) {
 					</>
 				) : null}
 				<List>
-					{currUserProfile.read_only_user ? (
-						<></>
-					) : (
+					{currUserProfile.read_only_user ? null : (
 						<ListItem key={"groups"} disablePadding>
 							<ListItemButton component={RouterLink} to="/groups">
 								<ListItemIcon>
@@ -390,7 +388,7 @@ export default function PersistentDrawerLeft(props) {
 						</ListItem>
 					)}
 				</List>
-				<Divider />
+				{currUserProfile.read_only_user ? <></> : <Divider />}
 				<List>
 					{currUserProfile.read_only_user ? (
 						<></>

--- a/frontend/src/components/PublicLayout.tsx
+++ b/frontend/src/components/PublicLayout.tsx
@@ -226,7 +226,6 @@ export default function PersistentDrawerLeft(props) {
 						)}
 					</IconButton>
 				</DrawerHeader>
-				<Divider />
 				<List>
 					<ListItem key={"public"} disablePadding>
 						<ListItemButton component={RouterLink} to="/public">
@@ -237,7 +236,6 @@ export default function PersistentDrawerLeft(props) {
 						</ListItemButton>
 					</ListItem>
 				</List>
-				<Divider />
 				<List>
 					<ListItem key={"public_search"} disablePadding>
 						<ListItemButton component={RouterLink} to="/public_search">
@@ -249,7 +247,6 @@ export default function PersistentDrawerLeft(props) {
 					</ListItem>
 				</List>
 				{/*<Divider />*/}
-				<Divider />
 			</Drawer>
 			<Main open={open}>
 				<DrawerHeader />


### PR DESCRIPTION
The bug was that if you were a read only user, you saw 2 dividers that were empty on the left.

Now you don't see those 2 dividers, but the 'search' section looks larger than it should.

Not sure how to fix it, so this is draft.
<img width="875" alt="left_panel_issues" src="https://github.com/clowder-framework/clowder2/assets/40038535/6fb7952b-57d5-4907-ae15-7762b5aafd6d">
