### PR TITLE
hide extracted results for now

### DIFF
--- a/frontend/src/components/listeners/SubmitExtraction.tsx
+++ b/frontend/src/components/listeners/SubmitExtraction.tsx
@@ -224,7 +224,7 @@ export default function SubmitExtraction(props: SubmitExtractionProps) {
 								</Step>
 								{/*step 2 results*/}
 								<Step key="results">
-									<StepLabel>Extracted Results</StepLabel>
+									{/*<StepLabel>Extracted Results</StepLabel>*/}
 									<StepContent>
 										{/*buttons*/}
 										<Box sx={{ mb: 2 }}>


### PR DESCRIPTION
Very small pull request, I'm just commenting out 'extracted results' since we don't currently show anything. The 'restart' button is still there, and if you go 'back' you can see the extractor as it progresses. 