### PR TITLE
919 doi support

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -88,5 +88,11 @@ class Settings(BaseSettings):
     # defautl listener heartbeat time interval in seconds 5 minutes
     listener_heartbeat_interval = 5 * 60
 
+    # DOI datacite details
+    DATACITE_TEST_URL = "https://api.test.datacite.org/dois"
+    DATACITE_URL = "https://api.datacite.org/dois"
+    DATACITE_USERNAME = "admin"
+    DATACITE_PASSWORD = "<PASSWORD>"
+
 
 settings = Settings()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -89,10 +89,9 @@ class Settings(BaseSettings):
     listener_heartbeat_interval = 5 * 60
 
     # DOI datacite details
+    DOI_ENABLED = True
     DATACITE_TEST_URL = "https://api.test.datacite.org/dois"
     DATACITE_URL = "https://api.datacite.org/dois"
-    DATACITE_USERNAME = "admin"
-    DATACITE_PASSWORD = "<PASSWORD>"
 
 
 settings = Settings()

--- a/backend/app/models/datasets.py
+++ b/backend/app/models/datasets.py
@@ -44,6 +44,7 @@ class DatasetBaseCommon(DatasetBase):
     origin_id: Optional[PydanticObjectId] = None
     standard_license: bool = True
     license_id: Optional[str] = None
+    doi: Optional[str] = None
 
 
 class DatasetPatch(BaseModel):

--- a/backend/app/routers/datasets.py
+++ b/backend/app/routers/datasets.py
@@ -74,7 +74,7 @@ from pymongo import DESCENDING
 from rocrate.model.person import Person
 from rocrate.rocrate import ROCrate
 
-from backend.app.routers.doi import DataCiteClient
+from app.routers.doi import DataCiteClient
 
 router = APIRouter()
 security = HTTPBearer()
@@ -148,12 +148,12 @@ def _describe_zip_contents(file_list: list):
 
 
 async def _create_folder_structure(
-    dataset_id: str,
-    contents: dict,
-    folder_path: str,
-    folder_lookup: dict,
-    user: UserOut,
-    parent_folder_id: Optional[str] = None,
+        dataset_id: str,
+        contents: dict,
+        folder_path: str,
+        folder_lookup: dict,
+        user: UserOut,
+        parent_folder_id: Optional[str] = None,
 ):
     """Recursively create folders encountered in folder_path until the target folder is created.
     Arguments:
@@ -189,10 +189,10 @@ async def _create_folder_structure(
 
 @router.post("", response_model=DatasetOut)
 async def save_dataset(
-    dataset_in: DatasetIn,
-    license_id: str,
-    user=Depends(get_current_user),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        dataset_in: DatasetIn,
+        license_id: str,
+        user=Depends(get_current_user),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
 ):
     standard_license = False
     standard_license_ids = [license.id for license in standard_licenses]
@@ -221,13 +221,13 @@ async def save_dataset(
 
 @router.get("", response_model=Paged)
 async def get_datasets(
-    user_id=Depends(get_user),
-    skip: int = 0,
-    limit: int = 10,
-    mine: bool = False,
-    admin=Depends(get_admin),
-    enable_admin: bool = False,
-    admin_mode: bool = Depends(get_admin_mode),
+        user_id=Depends(get_user),
+        skip: int = 0,
+        limit: int = 10,
+        mine: bool = False,
+        admin=Depends(get_admin),
+        enable_admin: bool = False,
+        admin_mode: bool = Depends(get_admin_mode),
 ):
     query = [DatasetDBViewList.frozen == False]  # noqa: E712
 
@@ -282,18 +282,18 @@ async def get_datasets(
 
 @router.get("/{dataset_id}", response_model=DatasetOut)
 async def get_dataset(
-    dataset_id: str,
-    authenticated: bool = Depends(CheckStatus("AUTHENTICATED")),
-    public: bool = Depends(CheckStatus("PUBLIC")),
-    allow: bool = Depends(Authorization("viewer")),
+        dataset_id: str,
+        authenticated: bool = Depends(CheckStatus("AUTHENTICATED")),
+        public: bool = Depends(CheckStatus("PUBLIC")),
+        allow: bool = Depends(Authorization("viewer")),
 ):
     if authenticated or public or allow:
         if (
-            dataset := await DatasetDBViewList.find_one(
-                Or(
-                    DatasetDBViewList.id == PydanticObjectId(dataset_id),
+                dataset := await DatasetDBViewList.find_one(
+                    Or(
+                        DatasetDBViewList.id == PydanticObjectId(dataset_id),
+                    )
                 )
-            )
         ) is not None:
             return dataset.dict()
         raise HTTPException(status_code=404, detail=f"Dataset {dataset_id} not found")
@@ -303,24 +303,24 @@ async def get_dataset(
 
 @router.get("/{dataset_id}/files", response_model=Paged)
 async def get_dataset_files(
-    dataset_id: str,
-    folder_id: Optional[str] = None,
-    authenticated: bool = Depends(CheckStatus("AUTHENTICATED")),
-    public: bool = Depends(CheckStatus("PUBLIC")),
-    user_id=Depends(get_user),
-    skip: int = 0,
-    limit: int = 10,
-    admin=Depends(get_admin),
-    enable_admin: bool = False,
-    admin_mode: bool = Depends(get_admin_mode),
-    allow: bool = Depends(Authorization("viewer")),
+        dataset_id: str,
+        folder_id: Optional[str] = None,
+        authenticated: bool = Depends(CheckStatus("AUTHENTICATED")),
+        public: bool = Depends(CheckStatus("PUBLIC")),
+        user_id=Depends(get_user),
+        skip: int = 0,
+        limit: int = 10,
+        admin=Depends(get_admin),
+        enable_admin: bool = False,
+        admin_mode: bool = Depends(get_admin_mode),
+        allow: bool = Depends(Authorization("viewer")),
 ):
     if (
-        await DatasetDBViewList.find_one(
-            Or(
-                DatasetDBViewList.id == PydanticObjectId(dataset_id),
+            await DatasetDBViewList.find_one(
+                Or(
+                    DatasetDBViewList.id == PydanticObjectId(dataset_id),
+                )
             )
-        )
     ) is not None:
         if authenticated or public or (admin and admin_mode):
             query = [
@@ -359,11 +359,11 @@ async def get_dataset_files(
 
 @router.put("/{dataset_id}", response_model=DatasetOut)
 async def edit_dataset(
-    dataset_id: str,
-    dataset_info: DatasetBase,
-    user=Depends(get_current_user),
-    es=Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("editor")),
+        dataset_id: str,
+        dataset_info: DatasetBase,
+        user=Depends(get_current_user),
+        es=Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("editor")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         # TODO: Refactor this with permissions checks etc.
@@ -376,7 +376,7 @@ async def edit_dataset(
 
         # Update folders index since its using dataset downloads and status to index
         async for folder in FolderDB.find(
-            FolderDB.dataset_id == PydanticObjectId(dataset_id)
+                FolderDB.dataset_id == PydanticObjectId(dataset_id)
         ):
             await index_folder(es, FolderOut(**folder.dict()), update=True)
 
@@ -386,11 +386,11 @@ async def edit_dataset(
 
 @router.patch("/{dataset_id}", response_model=DatasetOut)
 async def patch_dataset(
-    dataset_id: str,
-    dataset_info: DatasetPatch,
-    user=Depends(get_current_user),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("editor")),
+        dataset_id: str,
+        dataset_info: DatasetPatch,
+        user=Depends(get_current_user),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("editor")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         # TODO: Update method not working properly
@@ -410,7 +410,7 @@ async def patch_dataset(
             files_views = await FileDBViewList.find(*query).to_list()
             for file_view in files_views:
                 if (
-                    file := await FileDB.get(PydanticObjectId(file_view.id))
+                        file := await FileDB.get(PydanticObjectId(file_view.id))
                 ) is not None:
                     file.status = dataset_info.status
                     await file.save()
@@ -421,7 +421,7 @@ async def patch_dataset(
 
         # Update folders index since its using dataset downloads and status to index
         async for folder in FolderDB.find(
-            FolderDB.dataset_id == PydanticObjectId(dataset_id)
+                FolderDB.dataset_id == PydanticObjectId(dataset_id)
         ):
             await index_folder(es, FolderOut(**folder.dict()), update=True)
 
@@ -430,10 +430,10 @@ async def patch_dataset(
 
 @router.delete("/{dataset_id}")
 async def delete_dataset(
-    dataset_id: str,
-    fs: Minio = Depends(dependencies.get_fs),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("editor")),
+        dataset_id: str,
+        fs: Minio = Depends(dependencies.get_fs),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("editor")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         # delete from elasticsearch
@@ -441,7 +441,7 @@ async def delete_dataset(
 
         # find associate frozen datasets and delete them iteratively
         async for frozen_dataset in DatasetFreezeDB.find(
-            DatasetFreezeDB.origin_id == PydanticObjectId(dataset_id)
+                DatasetFreezeDB.origin_id == PydanticObjectId(dataset_id)
         ):
             await _delete_frozen_dataset(frozen_dataset, fs, hard_delete=True)
 
@@ -464,7 +464,7 @@ async def delete_dataset(
 
         # delete files and its associate resources
         async for file in FileDB.find(
-            FileDB.dataset_id == PydanticObjectId(dataset_id)
+                FileDB.dataset_id == PydanticObjectId(dataset_id)
         ):
             await remove_file_entry(file.id, fs, es)
 
@@ -486,11 +486,11 @@ async def delete_dataset(
 
 @router.post("/{dataset_id}/doi", response_model=str)
 async def mint_doi(
-    dataset_id: str,
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization(RoleType.OWNER)),
+        dataset_id: str,
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization(RoleType.OWNER)),
 ):
     dataset = await DatasetDB.get(PydanticObjectId(dataset_id))
     if dataset is None:
@@ -524,11 +524,11 @@ async def mint_doi(
 
 @router.post("/{dataset_id}/freeze", response_model=DatasetFreezeOut)
 async def freeze_dataset(
-    dataset_id: str,
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization(RoleType.OWNER)),
+        dataset_id: str,
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization(RoleType.OWNER)),
 ):
     # Retrieve the dataset by ID
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
@@ -551,7 +551,7 @@ async def freeze_dataset(
             frozen_dataset_data["frozen_version_num"] = 1
         else:
             frozen_dataset_data["frozen_version_num"] = (
-                latest_frozen_dataset.frozen_version_num + 1
+                    latest_frozen_dataset.frozen_version_num + 1
             )
 
         # start freezing associate information
@@ -592,13 +592,13 @@ async def freeze_dataset(
 
 @router.get("/{dataset_id}/freeze", response_model=Paged)
 async def get_freeze_datasets(
-    dataset_id: str,
-    skip: int = 0,
-    limit: int = 10,
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("owner")),
+        dataset_id: str,
+        skip: int = 0,
+        limit: int = 10,
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("owner")),
 ):
     frozen_datasets_and_count = (
         await DatasetFreezeDB.find(
@@ -627,11 +627,11 @@ async def get_freeze_datasets(
 
 @router.get("/{dataset_id}/freeze/latest_version_num", response_model=int)
 async def get_freeze_dataset_lastest_version_num(
-    dataset_id: str,
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("owner")),
+        dataset_id: str,
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("owner")),
 ):
     freeze_dataset_latest_version_num = -999
     latest_frozen_dataset = (
@@ -651,19 +651,19 @@ async def get_freeze_dataset_lastest_version_num(
     "/{dataset_id}/freeze/{frozen_version_num}", response_model=DatasetFreezeOut
 )
 async def get_freeze_dataset_version(
-    dataset_id: str,
-    frozen_version_num: int,
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("owner")),
+        dataset_id: str,
+        frozen_version_num: int,
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("owner")),
 ):
     # Retrieve the dataset by ID
     if (
-        frozen_dataset := await DatasetFreezeDB.find_one(
-            DatasetFreezeDB.origin_id == PydanticObjectId(dataset_id),
-            DatasetFreezeDB.frozen_version_num == frozen_version_num,
-        )
+            frozen_dataset := await DatasetFreezeDB.find_one(
+                DatasetFreezeDB.origin_id == PydanticObjectId(dataset_id),
+                DatasetFreezeDB.frozen_version_num == frozen_version_num,
+            )
     ) is not None:
         if frozen_dataset.deleted is True:
             raise HTTPException(
@@ -683,19 +683,19 @@ async def get_freeze_dataset_version(
     "/{dataset_id}/freeze/{frozen_version_num}", response_model=DatasetFreezeOut
 )
 async def delete_freeze_dataset_version(
-    dataset_id: str,
-    frozen_version_num: int,
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("owner")),
+        dataset_id: str,
+        frozen_version_num: int,
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("owner")),
 ):
     # Retrieve the frozen dataset by ID
     if (
-        frozen_dataset := await DatasetFreezeDB.find_one(
-            DatasetFreezeDB.origin_id == PydanticObjectId(dataset_id),
-            DatasetFreezeDB.frozen_version_num == frozen_version_num,
-        )
+            frozen_dataset := await DatasetFreezeDB.find_one(
+                DatasetFreezeDB.origin_id == PydanticObjectId(dataset_id),
+                DatasetFreezeDB.frozen_version_num == frozen_version_num,
+            )
     ) is not None:
         return await _delete_frozen_dataset(frozen_dataset, fs, hard_delete=False)
 
@@ -707,11 +707,11 @@ async def delete_freeze_dataset_version(
 
 @router.post("/{dataset_id}/folders", response_model=FolderOut)
 async def add_folder(
-    dataset_id: str,
-    folder_in: FolderIn,
-    user=Depends(get_current_user),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("uploader")),
+        dataset_id: str,
+        folder_in: FolderIn,
+        user=Depends(get_current_user),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("uploader")),
 ):
     if (await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         parent_folder = folder_in.parent_folder
@@ -731,21 +731,21 @@ async def add_folder(
 
 @router.get("/{dataset_id}/folders", response_model=Paged)
 async def get_dataset_folders(
-    dataset_id: str,
-    parent_folder: Optional[str] = None,
-    user_id=Depends(get_user),
-    authenticated: bool = Depends(CheckStatus("authenticated")),
-    public: bool = Depends(CheckStatus("PUBLIC")),
-    skip: int = 0,
-    limit: int = 10,
-    allow: bool = Depends(Authorization("viewer")),
+        dataset_id: str,
+        parent_folder: Optional[str] = None,
+        user_id=Depends(get_user),
+        authenticated: bool = Depends(CheckStatus("authenticated")),
+        public: bool = Depends(CheckStatus("PUBLIC")),
+        skip: int = 0,
+        limit: int = 10,
+        allow: bool = Depends(Authorization("viewer")),
 ):
     if (
-        await DatasetDBViewList.find_one(
-            Or(
-                DatasetDBViewList.id == PydanticObjectId(dataset_id),
+            await DatasetDBViewList.find_one(
+                Or(
+                    DatasetDBViewList.id == PydanticObjectId(dataset_id),
+                )
             )
-        )
     ) is not None:
         if authenticated or public:
             query = [
@@ -787,24 +787,24 @@ async def get_dataset_folders(
 
 @router.get("/{dataset_id}/folders_and_files", response_model=Paged)
 async def get_dataset_folders_and_files(
-    dataset_id: str,
-    folder_id: Optional[str] = None,
-    authenticated: bool = Depends(CheckStatus("AUTHENTICATED")),
-    public: bool = Depends(CheckStatus("PUBLIC")),
-    user_id=Depends(get_user),
-    skip: int = 0,
-    limit: int = 10,
-    admin=Depends(get_admin),
-    enable_admin: bool = False,
-    admin_mode: bool = Depends(get_admin_mode),
-    allow: bool = Depends(Authorization("viewer")),
+        dataset_id: str,
+        folder_id: Optional[str] = None,
+        authenticated: bool = Depends(CheckStatus("AUTHENTICATED")),
+        public: bool = Depends(CheckStatus("PUBLIC")),
+        user_id=Depends(get_user),
+        skip: int = 0,
+        limit: int = 10,
+        admin=Depends(get_admin),
+        enable_admin: bool = False,
+        admin_mode: bool = Depends(get_admin_mode),
+        allow: bool = Depends(Authorization("viewer")),
 ):
     if (
-        await DatasetDBViewList.find_one(
-            Or(
-                DatasetDBViewList.id == PydanticObjectId(dataset_id),
+            await DatasetDBViewList.find_one(
+                Or(
+                    DatasetDBViewList.id == PydanticObjectId(dataset_id),
+                )
             )
-        )
     ) is not None:
         if authenticated or public or (admin and admin_mode):
             query = [
@@ -869,11 +869,11 @@ async def get_dataset_folders_and_files(
 
 @router.delete("/{dataset_id}/folders/{folder_id}")
 async def delete_folder(
-    dataset_id: str,
-    folder_id: str,
-    fs: Minio = Depends(dependencies.get_fs),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    allow: bool = Depends(Authorization("editor")),
+        dataset_id: str,
+        folder_id: str,
+        fs: Minio = Depends(dependencies.get_fs),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        allow: bool = Depends(Authorization("editor")),
 ):
     if (await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         if (folder := await FolderDB.get(PydanticObjectId(folder_id))) is not None:
@@ -884,14 +884,14 @@ async def delete_folder(
             # recursively delete child folder and files
             async def _delete_nested_folders(parent_folder_id):
                 while (
-                    await FolderDB.find_one(
-                        FolderDB.dataset_id == ObjectId(dataset_id),
-                        FolderDB.parent_folder == ObjectId(parent_folder_id),
-                    )
+                        await FolderDB.find_one(
+                            FolderDB.dataset_id == ObjectId(dataset_id),
+                            FolderDB.parent_folder == ObjectId(parent_folder_id),
+                        )
                 ) is not None:
                     async for subfolder in FolderDB.find(
-                        FolderDB.dataset_id == PydanticObjectId(dataset_id),
-                        FolderDB.parent_folder == PydanticObjectId(parent_folder_id),
+                            FolderDB.dataset_id == PydanticObjectId(dataset_id),
+                            FolderDB.parent_folder == PydanticObjectId(parent_folder_id),
                     ):
                         async for file in FileDB.find(FileDB.folder_id == subfolder.id):
                             await remove_file_entry(file.id, fs, es)
@@ -910,16 +910,16 @@ async def delete_folder(
 
 @router.get("/{dataset_id}/folders/{folder_id}")
 async def get_folder(
-    dataset_id: str,
-    folder_id: str,
-    allow: bool = Depends(Authorization("viewer")),
+        dataset_id: str,
+        folder_id: str,
+        allow: bool = Depends(Authorization("viewer")),
 ):
     if (
-        await DatasetDBViewList.find_one(
-            Or(
-                DatasetDBViewList.id == PydanticObjectId(dataset_id),
+            await DatasetDBViewList.find_one(
+                Or(
+                    DatasetDBViewList.id == PydanticObjectId(dataset_id),
+                )
             )
-        )
     ) is not None:
         if (folder := await FolderDB.get(PydanticObjectId(folder_id))) is not None:
             return folder.dict()
@@ -930,12 +930,12 @@ async def get_folder(
 
 @router.patch("/{dataset_id}/folders/{folder_id}", response_model=FolderOut)
 async def patch_folder(
-    dataset_id: str,
-    folder_id: str,
-    folder_info: FolderPatch,
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    user=Depends(get_current_user),
-    allow: bool = Depends(Authorization("editor")),
+        dataset_id: str,
+        folder_id: str,
+        folder_info: FolderPatch,
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        user=Depends(get_current_user),
+        allow: bool = Depends(Authorization("editor")),
 ):
     if await DatasetDB.get(PydanticObjectId(dataset_id)) is not None:
         if (folder := await FolderDB.get(PydanticObjectId(folder_id))) is not None:
@@ -945,8 +945,8 @@ async def patch_folder(
             # allow moving folder around within the hierarchy
             if folder_info.parent_folder is not None:
                 if (
-                    await FolderDB.get(PydanticObjectId(folder_info.parent_folder))
-                    is not None
+                        await FolderDB.get(PydanticObjectId(folder_info.parent_folder))
+                        is not None
                 ):
                     folder.parent_folder = folder_info.parent_folder
             folder.modified = datetime.datetime.utcnow()
@@ -965,14 +965,14 @@ async def patch_folder(
 
 @router.post("/{dataset_id}/files", response_model=FileOut)
 async def save_file(
-    dataset_id: str,
-    folder_id: Optional[str] = None,
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    file: UploadFile = File(...),
-    es=Depends(dependencies.get_elasticsearchclient),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
-    allow: bool = Depends(Authorization("uploader")),
+        dataset_id: str,
+        folder_id: Optional[str] = None,
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        file: UploadFile = File(...),
+        es=Depends(dependencies.get_elasticsearchclient),
+        rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+        allow: bool = Depends(Authorization("uploader")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         if user is None:
@@ -1017,14 +1017,14 @@ async def save_file(
 
 @router.post("/{dataset_id}/filesMultiple", response_model=List[FileOut])
 async def save_files(
-    dataset_id: str,
-    files: List[UploadFile],
-    folder_id: Optional[str] = None,
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    es=Depends(dependencies.get_elasticsearchclient),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
-    allow: bool = Depends(Authorization("uploader")),
+        dataset_id: str,
+        files: List[UploadFile],
+        folder_id: Optional[str] = None,
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        es=Depends(dependencies.get_elasticsearchclient),
+        rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+        allow: bool = Depends(Authorization("uploader")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         files_added = []
@@ -1044,7 +1044,7 @@ async def save_files(
 
             if folder_id is not None:
                 if (
-                    folder := await FolderDB.get(PydanticObjectId(folder_id))
+                        folder := await FolderDB.get(PydanticObjectId(folder_id))
                 ) is not None:
                     new_file.folder_id = folder.id
                 else:
@@ -1078,13 +1078,13 @@ async def save_files(
 
 @router.post("/{dataset_id}/local_files", response_model=FileOut)
 async def save_local_file(
-    localfile_in: LocalFileIn,
-    dataset_id: str,
-    folder_id: Optional[str] = None,
-    user=Depends(get_current_user),
-    es=Depends(dependencies.get_elasticsearchclient),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
-    allow: bool = Depends(Authorization("uploader")),
+        localfile_in: LocalFileIn,
+        dataset_id: str,
+        folder_id: Optional[str] = None,
+        user=Depends(get_current_user),
+        es=Depends(dependencies.get_elasticsearchclient),
+        rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+        allow: bool = Depends(Authorization("uploader")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         if user is None:
@@ -1133,12 +1133,12 @@ async def save_local_file(
 
 @router.post("/createFromZip", response_model=DatasetOut)
 async def create_dataset_from_zip(
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    file: UploadFile = File(...),
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
-    token: str = Depends(get_token),
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        file: UploadFile = File(...),
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+        token: str = Depends(get_token),
 ):
     if file.filename.endswith(".zip") is False:
         raise HTTPException(status_code=404, detail="File is not a zip file")
@@ -1206,16 +1206,16 @@ async def create_dataset_from_zip(
 
 @router.get("/{dataset_id}/download")
 async def download_dataset(
-    dataset_id: str,
-    es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    user=Depends(get_current_user),
-    fs: Minio = Depends(dependencies.get_fs),
-    allow: bool = Depends(Authorization("viewer")),
+        dataset_id: str,
+        es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
+        user=Depends(get_current_user),
+        fs: Minio = Depends(dependencies.get_fs),
+        allow: bool = Depends(Authorization("viewer")),
 ):
     if (
-        dataset := await DatasetDBViewList.find_one(
-            DatasetDBViewList.id == PydanticObjectId(dataset_id)
-        )
+            dataset := await DatasetDBViewList.find_one(
+                DatasetDBViewList.id == PydanticObjectId(dataset_id)
+            )
     ) is not None:
         current_temp_dir = tempfile.mkdtemp(prefix="rocratedownload")
         crate = ROCrate()
@@ -1260,7 +1260,7 @@ async def download_dataset(
         file_count = 0
 
         async for file in FileDBViewList.find(
-            FileDBViewList.dataset_id == ObjectId(dataset_id)
+                FileDBViewList.dataset_id == ObjectId(dataset_id)
         ):
             # find the bytes id
             # if it's working draft file_id == origin_id
@@ -1376,7 +1376,7 @@ async def download_dataset(
         await index_dataset(es, DatasetOut(**dataset.dict()), update=True)
         # Update folders index since its using dataset downloads and status to index
         async for folder in FolderDB.find(
-            FolderDB.dataset_id == PydanticObjectId(dataset_id)
+                FolderDB.dataset_id == PydanticObjectId(dataset_id)
         ):
             await index_folder(es, FolderOut(**folder.dict()), update=True)
 
@@ -1388,14 +1388,14 @@ async def download_dataset(
 # can handle parameeters pass in as key/values in info
 @router.post("/{dataset_id}/extract")
 async def get_dataset_extract(
-    dataset_id: str,
-    extractorName: str,
-    request: Request,
-    # parameters don't have a fixed model shape
-    parameters: dict = None,
-    user=Depends(get_current_user),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
-    allow: bool = Depends(Authorization("uploader")),
+        dataset_id: str,
+        extractorName: str,
+        request: Request,
+        # parameters don't have a fixed model shape
+        parameters: dict = None,
+        user=Depends(get_current_user),
+        rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+        allow: bool = Depends(Authorization("uploader")),
 ):
     if extractorName is None:
         raise HTTPException(status_code=400, detail="No extractorName specified")
@@ -1415,17 +1415,17 @@ async def get_dataset_extract(
 
 @router.get("/{dataset_id}/thumbnail")
 async def download_dataset_thumbnail(
-    dataset_id: str,
-    fs: Minio = Depends(dependencies.get_fs),
-    allow: bool = Depends(Authorization("viewer")),
+        dataset_id: str,
+        fs: Minio = Depends(dependencies.get_fs),
+        allow: bool = Depends(Authorization("viewer")),
 ):
     # If dataset exists in MongoDB, download from Minio
     if (
-        dataset := await DatasetDBViewList.find_one(
-            Or(
-                DatasetDBViewList.id == PydanticObjectId(dataset_id),
+            dataset := await DatasetDBViewList.find_one(
+                Or(
+                    DatasetDBViewList.id == PydanticObjectId(dataset_id),
+                )
             )
-        )
     ) is not None:
         if dataset.thumbnail_id is not None:
             content = fs.get_object(
@@ -1448,9 +1448,9 @@ async def download_dataset_thumbnail(
 
 @router.patch("/{dataset_id}/thumbnail/{thumbnail_id}", response_model=DatasetOut)
 async def add_dataset_thumbnail(
-    dataset_id: str,
-    thumbnail_id: str,
-    allow: bool = Depends(Authorization("editor")),
+        dataset_id: str,
+        thumbnail_id: str,
+        allow: bool = Depends(Authorization("editor")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
         if (await ThumbnailDB.get(PydanticObjectId(thumbnail_id))) is not None:

--- a/backend/app/routers/datasets.py
+++ b/backend/app/routers/datasets.py
@@ -497,10 +497,14 @@ async def mint_doi(
                 "type": "dois",
                 "attributes": {
                     "prefix": os.getenv("DATACITE_PREFIX"),
-                    "url": f"{settings.API_HOST}{settings.API_V2_STR}/datasets/{dataset_id}",
+                    "url": f"{settings.frontend_url}/datasets/{dataset_id}",
                     "titles": [{"title": dataset.name}],
                     "creators": [
-                        {"name": dataset.creator.first_name + dataset.creator.last_name}
+                        {
+                            "name": dataset.creator.first_name
+                            + " "
+                            + dataset.creator.last_name
+                        }
                     ],
                     "publisher": "DataCite e.V.",
                     "publicationYear": datetime.datetime.now().year,

--- a/backend/app/routers/doi.py
+++ b/backend/app/routers/doi.py
@@ -1,11 +1,14 @@
-from app.config import settings
-from fastapi import requests
+import os
+
+import requests
 from requests.auth import HTTPBasicAuth
 
 
 class DataCiteClient:
-    def __init__(self, test_mode=True):
-        self.auth = HTTPBasicAuth(settings.USERNAME, settings.PASSWORD)
+    def __init__(self, test_mode=False):
+        self.auth = HTTPBasicAuth(
+            os.getenv("DATACITE_USERNAME"), os.getenv("DATACITE_PASSWORD")
+        )
         self.headers = {"Content-Type": "application/vnd.api+json"}
         self.base_url = (
             "https://api.test.datacite.org/"

--- a/backend/app/routers/doi.py
+++ b/backend/app/routers/doi.py
@@ -1,0 +1,48 @@
+from app.config import settings
+from fastapi import requests
+from requests.auth import HTTPBasicAuth
+
+
+class DataCiteClient:
+    def __init__(self, test_mode=True):
+        self.auth = HTTPBasicAuth(settings.USERNAME, settings.PASSWORD)
+        self.headers = {"Content-Type": "application/vnd.api+json"}
+        self.base_url = (
+            "https://api.test.datacite.org/"
+            if test_mode
+            else "https://api.datacite.org/"
+        )
+
+    def create_doi(self, metadata):
+        url = f"{self.base_url}dois"
+        response = requests.post(
+            url, auth=self.auth, headers=self.headers, json=metadata
+        )
+        return response.json()
+
+    def get_all_dois(self):
+        url = f"{self.base_url}dois"
+        response = requests.get(url, auth=self.auth, headers=self.headers)
+        return response.json()
+
+    def get_doi(self, doi):
+        url = f"{self.base_url}dois/{doi}"
+        response = requests.get(url, auth=self.auth, headers=self.headers)
+        return response.json()
+
+    def update_doi(self, doi, metadata):
+        url = f"{self.base_url}dois/{doi}"
+        response = requests.put(
+            url, auth=self.auth, headers=self.headers, json=metadata
+        )
+        return response.json()
+
+    def delete_doi(self, doi):
+        url = f"{self.base_url}dois/{doi}"
+        response = requests.delete(url, auth=self.auth, headers=self.headers)
+        return response.status_code == 204
+
+    def get_doi_activity_status(self, doi):
+        url = f"{self.base_url}events?doi={doi}"
+        response = requests.get(url, auth=self.auth, headers=self.headers)
+        return response.json()

--- a/backend/app/tests/test_datasets.py
+++ b/backend/app/tests/test_datasets.py
@@ -30,12 +30,6 @@ def test_create_doi(client: TestClient, headers: dict):
     )
     assert response.status_code == 200
     assert response.json().get("id") is not None
-    response = client.post(
-        f"{settings.API_V2_STR}/datasets/{dataset_id}/doi", headers=headers
-    )
-    assert response.status_code == 200
-    print(response.json())
-    assert response.json().get("doi") is not None
 
 
 def test_delete(client: TestClient, headers: dict):

--- a/backend/app/tests/test_datasets.py
+++ b/backend/app/tests/test_datasets.py
@@ -23,6 +23,21 @@ def test_get_one(client: TestClient, headers: dict):
     assert response.json().get("id") is not None
 
 
+def test_create_doi(client: TestClient, headers: dict):
+    dataset_id = create_dataset(client, headers).get("id")
+    response = client.get(
+        f"{settings.API_V2_STR}/datasets/{dataset_id}", headers=headers
+    )
+    assert response.status_code == 200
+    assert response.json().get("id") is not None
+    response = client.post(
+        f"{settings.API_V2_STR}/datasets/{dataset_id}/doi", headers=headers
+    )
+    assert response.status_code == 200
+    print(response.json())
+    assert response.json().get("doi") is not None
+
+
 def test_delete(client: TestClient, headers: dict):
     dataset_id = create_dataset(client, headers).get("id")
     response = client.delete(

--- a/frontend/src/actions/dataset.js
+++ b/frontend/src/actions/dataset.js
@@ -186,10 +186,11 @@ export function updateDataset(datasetId, formData) {
 
 export const FREEZE_DATASET = "FREEZE_DATASET";
 
-export function freezeDataset(datasetId) {
+export function freezeDataset(datasetId, publishDOI = false) {
 	return (dispatch) => {
 		return V2.DatasetsService.freezeDatasetApiV2DatasetsDatasetIdFreezePost(
-			datasetId
+			datasetId,
+			publishDOI
 		)
 			.then((json) => {
 				dispatch({

--- a/frontend/src/app.config.ts
+++ b/frontend/src/app.config.ts
@@ -33,6 +33,7 @@ interface Config {
 	defaultExtractionJobs: number;
 	defaultMetadataDefintionPerPage: number;
 	defaultVersionPerPage: number;
+	enableDOI: boolean;
 }
 
 const config: Config = <Config>{};
@@ -100,5 +101,6 @@ config["defaultFeeds"] = 5;
 config["defaultExtractionJobs"] = 5;
 config["defaultMetadataDefintionPerPage"] = 5;
 config["defaultVersionPerPage"] = 3;
+config["enableDOI"] = true;
 
 export default config;

--- a/frontend/src/components/datasets/DatasetDetails.tsx
+++ b/frontend/src/components/datasets/DatasetDetails.tsx
@@ -11,13 +11,15 @@ type DatasetAboutProps = {
 
 export function DatasetDetails(props: DatasetAboutProps) {
 	const { myRole } = props;
-	const { id, created, modified, creator, status, downloads } = props.details;
+	const { id, created, modified, creator, status, downloads, doi } =
+		props.details;
 
 	const details = new Map<
 		string,
 		{ value: string | undefined; info?: string }
 	>();
 	details.set("Owner", { value: `${creator.first_name} ${creator.last_name}` });
+	if (doi != null) details.set("DOI", { value: doi });
 	details.set("Created", {
 		value: parseDate(created),
 		info: "Date and time of dataset creation",

--- a/frontend/src/components/datasets/OtherMenu.tsx
+++ b/frontend/src/components/datasets/OtherMenu.tsx
@@ -46,8 +46,10 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 	const datasetRole = useSelector(
 		(state: RootState) => state.dataset.datasetRole
 	);
-	const freezeDataset = (datasetId: string | undefined) =>
-		dispatch(freezeDatasetAction(datasetId));
+	const freezeDataset = (
+		datasetId: string | undefined,
+		publishDOI: boolean | undefined
+	) => dispatch(freezeDatasetAction(datasetId, publishDOI));
 
 	const listGroups = () => dispatch(fetchGroups(0, 21));
 
@@ -130,7 +132,7 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 				actionText="By proceeding with the release, you will lock in the current content of the dataset, including all associated files, folders, metadata, and visualizations. Once released, these elements will be set as final and cannot be altered. However, you can continue to make edits and improvements on the ongoing version of the dataset."
 				actionBtnName="Release"
 				handleActionBtnClick={() => {
-					freezeDataset(datasetId);
+					freezeDataset(datasetId, true);
 					setFreezeDatasetConfirmOpen(false);
 				}}
 				handleActionCancel={() => {

--- a/frontend/src/components/datasets/OtherMenu.tsx
+++ b/frontend/src/components/datasets/OtherMenu.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import { ActionModal } from "../dialog/ActionModal";
+import { ActionModalWithCheckbox } from "../dialog/ActionModalWithCheckbox";
 import {
 	datasetDeleted,
 	freezeDataset as freezeDatasetAction,
@@ -89,6 +90,7 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 	};
 
 	const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
+	const [publishDOI, setPublishDOI] = React.useState<boolean>(false);
 
 	const handleOptionClick = (event: React.MouseEvent<any>) => {
 		setAnchorEl(event.currentTarget);
@@ -126,13 +128,17 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 				}}
 				actionLevel={"error"}
 			/>
-			<ActionModal
+			<ActionModalWithCheckbox
 				actionOpen={freezeDatasetConfirmOpen}
 				actionTitle="Are you ready to release this version of the dataset?"
 				actionText="By proceeding with the release, you will lock in the current content of the dataset, including all associated files, folders, metadata, and visualizations. Once released, these elements will be set as final and cannot be altered. However, you can continue to make edits and improvements on the ongoing version of the dataset."
+				checkboxLabel="Select this checkbox to publish this version of the dataset and get a DOI."
+				checkboxSelected={false}
 				actionBtnName="Release"
+				publishDOI={publishDOI}
+				setPublishDOI={setPublishDOI}
 				handleActionBtnClick={() => {
-					freezeDataset(datasetId, true);
+					freezeDataset(datasetId, publishDOI);
 					setFreezeDatasetConfirmOpen(false);
 				}}
 				handleActionCancel={() => {

--- a/frontend/src/components/datasets/OtherMenu.tsx
+++ b/frontend/src/components/datasets/OtherMenu.tsx
@@ -131,12 +131,11 @@ export const OtherMenu = (props: ActionsMenuProps): JSX.Element => {
 			<ActionModalWithCheckbox
 				actionOpen={freezeDatasetConfirmOpen}
 				actionTitle="Are you ready to release this version of the dataset?"
-				actionText="By proceeding with the release, you will lock in the current content of the dataset, including all associated files, folders, metadata, and visualizations. Once released, these elements will be set as final and cannot be altered. However, you can continue to make edits and improvements on the ongoing version of the dataset."
-				checkboxLabel="Select this checkbox to publish this version of the dataset and get a DOI."
-				checkboxSelected={false}
+				actionText="By proceeding with the release, you will lock in the current content of the dataset, including all associated files, folders, metadata, and visualizations. Once released, these elements will be set as final and cannot be altered. However, you can continue to make edits and improvements on the ongoing version of the dataset. Optionally, you can also generate a Digital Object Identifier (DOI) by selecting the checkbox below. It will be displayed in the dataset page in the Details section."
+				checkboxLabel="Generate a DOI for this version of the dataset."
+				checkboxSelected={publishDOI}
+				setCheckboxSelected={setPublishDOI}
 				actionBtnName="Release"
-				publishDOI={publishDOI}
-				setPublishDOI={setPublishDOI}
 				handleActionBtnClick={() => {
 					freezeDataset(datasetId, publishDOI);
 					setFreezeDatasetConfirmOpen(false);

--- a/frontend/src/components/dialog/ActionModalWithCheckbox.tsx
+++ b/frontend/src/components/dialog/ActionModalWithCheckbox.tsx
@@ -19,7 +19,7 @@ type ActionModalProps = {
 	checkboxLabel: string;
 	checkboxSelected: boolean;
 	publishDOI: boolean;
-	setPublishDOI: (value: boolean) => void;
+	setCheckboxSelected: (value: boolean) => void;
 	actionBtnName: string;
 	handleActionBtnClick: () => void;
 	handleActionCancel: () => void;
@@ -35,8 +35,7 @@ export const ActionModalWithCheckbox: React.FC<ActionModalProps> = (
 		actionText,
 		checkboxLabel,
 		checkboxSelected,
-		publishDOI,
-		setPublishDOI,
+		setCheckboxSelected,
 		actionBtnName,
 		handleActionBtnClick,
 		handleActionCancel,
@@ -48,13 +47,14 @@ export const ActionModalWithCheckbox: React.FC<ActionModalProps> = (
 			<DialogTitle id="confirmation-dialog-title">{actionTitle}</DialogTitle>
 			<DialogContent>
 				<DialogContentText>{actionText}</DialogContentText>
+				<br />
 				<FormControlLabel
+					value={"end"}
 					control={
 						<Checkbox
-							size={"small"}
 							defaultChecked={checkboxSelected}
 							onChange={() => {
-								setPublishDOI(!publishDOI);
+								setCheckboxSelected(!checkboxSelected);
 							}}
 						/>
 					}
@@ -63,18 +63,18 @@ export const ActionModalWithCheckbox: React.FC<ActionModalProps> = (
 			</DialogContent>
 			<DialogActions>
 				<Button
-					variant="contained"
-					onClick={handleActionBtnClick}
-					color={actionLevel ?? "primary"}
-				>
-					{actionBtnName}
-				</Button>
-				<Button
 					variant="outlined"
 					onClick={handleActionCancel}
 					color={actionLevel ?? "primary"}
 				>
 					Cancel
+				</Button>
+				<Button
+					variant="contained"
+					onClick={handleActionBtnClick}
+					color={actionLevel ?? "primary"}
+				>
+					{actionBtnName}
 				</Button>
 			</DialogActions>
 		</Dialog>

--- a/frontend/src/components/dialog/ActionModalWithCheckbox.tsx
+++ b/frontend/src/components/dialog/ActionModalWithCheckbox.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import {
+	Button,
+	Checkbox,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	DialogTitle,
+	FormControlLabel,
+} from "@mui/material";
+
+type ActionLevel = "error" | "warning" | "info";
+
+type ActionModalProps = {
+	actionOpen: boolean;
+	actionTitle: string;
+	actionText: string;
+	checkboxLabel: string;
+	checkboxSelected: boolean;
+	publishDOI: boolean;
+	setPublishDOI: (value: boolean) => void;
+	actionBtnName: string;
+	handleActionBtnClick: () => void;
+	handleActionCancel: () => void;
+	actionLevel?: ActionLevel;
+};
+
+export const ActionModalWithCheckbox: React.FC<ActionModalProps> = (
+	props: ActionModalProps
+) => {
+	const {
+		actionOpen,
+		actionTitle,
+		actionText,
+		checkboxLabel,
+		checkboxSelected,
+		publishDOI,
+		setPublishDOI,
+		actionBtnName,
+		handleActionBtnClick,
+		handleActionCancel,
+		actionLevel,
+	} = props;
+
+	return (
+		<Dialog open={actionOpen} onClose={handleActionCancel} maxWidth={"sm"}>
+			<DialogTitle id="confirmation-dialog-title">{actionTitle}</DialogTitle>
+			<DialogContent>
+				<DialogContentText>{actionText}</DialogContentText>
+				<FormControlLabel
+					control={
+						<Checkbox
+							size={"small"}
+							defaultChecked={checkboxSelected}
+							onChange={() => {
+								setPublishDOI(!publishDOI);
+							}}
+						/>
+					}
+					label={checkboxLabel}
+				/>
+			</DialogContent>
+			<DialogActions>
+				<Button
+					variant="contained"
+					onClick={handleActionBtnClick}
+					color={actionLevel ?? "primary"}
+				>
+					{actionBtnName}
+				</Button>
+				<Button
+					variant="outlined"
+					onClick={handleActionCancel}
+					color={actionLevel ?? "primary"}
+				>
+					Cancel
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+};

--- a/frontend/src/openapi/v2/models/DatasetFreezeOut.ts
+++ b/frontend/src/openapi/v2/models/DatasetFreezeOut.ts
@@ -30,6 +30,7 @@ export type DatasetFreezeOut = {
     origin_id?: string;
     standard_license?: boolean;
     license_id?: string;
+    doi?: string;
     id?: string;
     frozen?: boolean;
     frozen_version_num: number;

--- a/frontend/src/openapi/v2/models/DatasetOut.ts
+++ b/frontend/src/openapi/v2/models/DatasetOut.ts
@@ -30,6 +30,7 @@ export type DatasetOut = {
     origin_id?: string;
     standard_license?: boolean;
     license_id?: string;
+    doi?: string;
     id?: string;
     frozen?: boolean;
     frozen_version_num?: number;

--- a/frontend/src/openapi/v2/services/DatasetsService.ts
+++ b/frontend/src/openapi/v2/services/DatasetsService.ts
@@ -243,19 +243,19 @@ export class DatasetsService {
     /**
      * Mint Doi
      * @param datasetId
-     * @param enableAdmin
-     * @returns string Successful Response
+     * @param allow
+     * @returns DatasetOut Successful Response
      * @throws ApiError
      */
     public static mintDoiApiV2DatasetsDatasetIdDoiPost(
         datasetId: string,
-        enableAdmin: boolean = false,
-    ): CancelablePromise<string> {
+        allow: boolean = true,
+    ): CancelablePromise<DatasetOut> {
         return __request({
             method: 'POST',
             path: `/api/v2/datasets/${datasetId}/doi`,
             query: {
-                'enable_admin': enableAdmin,
+                'allow': allow,
             },
             errors: {
                 422: `Validation Error`,
@@ -295,18 +295,21 @@ export class DatasetsService {
     /**
      * Freeze Dataset
      * @param datasetId
+     * @param publishDoi
      * @param enableAdmin
      * @returns DatasetFreezeOut Successful Response
      * @throws ApiError
      */
     public static freezeDatasetApiV2DatasetsDatasetIdFreezePost(
         datasetId: string,
+        publishDoi: boolean = false,
         enableAdmin: boolean = false,
     ): CancelablePromise<DatasetFreezeOut> {
         return __request({
             method: 'POST',
             path: `/api/v2/datasets/${datasetId}/freeze`,
             query: {
+                'publish_doi': publishDoi,
                 'enable_admin': enableAdmin,
             },
             errors: {

--- a/frontend/src/openapi/v2/services/DatasetsService.ts
+++ b/frontend/src/openapi/v2/services/DatasetsService.ts
@@ -241,6 +241,29 @@ export class DatasetsService {
     }
 
     /**
+     * Mint Doi
+     * @param datasetId
+     * @param enableAdmin
+     * @returns string Successful Response
+     * @throws ApiError
+     */
+    public static mintDoiApiV2DatasetsDatasetIdDoiPost(
+        datasetId: string,
+        enableAdmin: boolean = false,
+    ): CancelablePromise<string> {
+        return __request({
+            method: 'POST',
+            path: `/api/v2/datasets/${datasetId}/doi`,
+            query: {
+                'enable_admin': enableAdmin,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
      * Get Freeze Datasets
      * @param datasetId
      * @param skip


### PR DESCRIPTION
Implemented DOI support for datasets. DOIs are also available once you release a version. 

You have to set the following as environment variables:
1. DATACITE_USERNAME
2. DATACITE_PASSWORD
3. DATACITE_PREFIX

Also note, all DOIs created are in draft state now. Once we are ready, we need to add a flag "event": "publish" to actually create public DOIs. Refer [here](https://support.datacite.org/docs/api-create-dois) for details.


Steps:
1. Release a version
2. Click on the checkbox in the dialog form to enable 'publishing DOI'
3. It should create a DOI for that version of dataset.
<img width="1396" alt="Screenshot 2024-07-30 at 1 47 37 PM" src="https://github.com/user-attachments/assets/f823d445-a302-4ae0-95ae-9565745c7497">
<img width="614" alt="Screenshot 2024-07-30 at 1 47 52 PM" src="https://github.com/user-attachments/assets/8829d5e7-d2cf-46e3-b1c2-b4473cf5475f">
<img width="347" alt="Screenshot 2024-07-30 at 1 48 06 PM" src="https://github.com/user-attachments/assets/8fa6e5f5-7006-4b05-8300-d4b74a7b4f4d">
