### PR TITLE
error in creating datasets when using docker-compose, newer backend tag used

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   backend:
-    image: 'clowder/clowder2-backend:2.0.0-beta.2'
+    image: 'clowder/clowder2-backend:release-v2.0-beta-3'
     restart: unless-stopped
     build:
       context: ./backend


### PR DESCRIPTION
Using docker compose during the hackathon I noticed an error would happen when users create datasets. The reason is that the image used for the backend did not include license feature, so I used a later release here. 