### PR TITLE
Fix/beta 3 extractions list

### DIFF
--- a/backend/message_listener.py
+++ b/backend/message_listener.py
@@ -16,7 +16,7 @@ from app.models.listeners import (
     EventListenerJobStatus,
     EventListenerJobUpdateDB,
 )
-from bson import ObjectId
+from beanie import PydanticObjectId
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -131,6 +131,7 @@ services:
     environment:
       - cluster.name=clowder2
       - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - xpack.security.enabled=false
       - xpack.security.http.ssl.enabled=false
       - http.cors.allow-origin='*'

--- a/frontend/src/components/listeners/ExtractionHistoryTab.tsx
+++ b/frontend/src/components/listeners/ExtractionHistoryTab.tsx
@@ -1,148 +1,40 @@
 import React, { useEffect, useState } from "react";
 
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "../../types/data";
+import { useDispatch } from "react-redux";
 import { fetchListenerJobs } from "../../actions/listeners";
 import { ExtractionJobs } from "./ExtractionJobs";
 import { format } from "date-fns";
-import { parseDate } from "../../utils/common";
 
-const createData = (
-	status: string,
-	jobId: string,
-	listener_id: string,
-	created: string,
-	creator: string,
-	duration: number
-) => {
-	return {
-		status,
-		listener_id,
-		jobId,
-		created,
-		creator,
-		duration,
-	};
-};
-
-const headCells = [
-	{
-		id: "status",
-		label: "",
-	},
-	{
-		id: "listener_id",
-		label: "Extractor Name",
-	},
-	{
-		id: "jobId",
-		label: "Job ID",
-	},
-	{
-		id: "created",
-		label: "Submitted At",
-	},
-	{
-		id: "creator",
-		label: "Submitted By",
-	},
-	{
-		id: "duration",
-		label: "Duration",
-	},
-];
 export const ExtractionHistoryTab = (props): JSX.Element => {
 	const { datasetId, fileId } = props;
 
 	const dispatch = useDispatch();
-	const listListenerJobs = (
-		listenerId: string | null,
-		status: string | null,
-		userId: string | null,
-		fileId: string | null,
-		datasetId: string | null,
-		created: string | null,
-		skip: number,
-		limit: number
-	) =>
-		dispatch(
-			fetchListenerJobs(
-				listenerId,
-				status,
-				userId,
-				fileId,
-				datasetId,
-				created,
-				skip,
-				limit
-			)
-		);
 
-	const jobs = useSelector((state: RootState) => state.listener.jobs);
-
-	const [executionJobsTableRow, setExecutionJobsTableRow] = useState([]);
 	const [selectedStatus, setSelectedStatus] = useState(null);
 	const [selectedCreatedTime, setSelectedCreatedTime] = useState(null);
 
 	useEffect(() => {
-		listListenerJobs(
-			null,
-			null,
-			null,
-			fileId ? fileId : null,
-			datasetId ? datasetId : null,
-			null,
-			0,
-			100
-		);
-	}, []);
-
-	const handleRefresh = () => {
-		listListenerJobs(
-			null,
-			selectedStatus,
-			null,
-			fileId ? fileId : null,
-			datasetId ? datasetId : null,
-			selectedCreatedTime ? format(selectedCreatedTime, "yyyy-MM-dd") : null,
-			0,
-			100
-		);
-	};
-
-	useEffect(() => {
 		// TODO add pagination for jobs
-		handleRefresh();
-	}, [selectedStatus, selectedCreatedTime]);
-
-	useEffect(() => {
-		const rows = [];
-		if (jobs.length > 0) {
-			jobs.map((job) => {
-				rows.push(
-					createData(
-						job["status"],
-						job["id"],
-						job["listener_id"],
-						parseDate(job["created"]),
-						job["creator"]["email"],
-						`${job["duration"]} sec`
-					)
-				);
-			});
-		}
-		setExecutionJobsTableRow(rows);
-	}, [jobs]);
+		dispatch(
+			fetchListenerJobs(
+				null,
+				selectedStatus,
+				null,
+				fileId,
+				datasetId,
+				selectedCreatedTime ? format(selectedCreatedTime, "yyyy-MM-dd") : null,
+				0,
+				100
+			)
+		);
+	}, [selectedStatus, selectedCreatedTime, dispatch]);
 
 	return (
 		<ExtractionJobs
-			rows={executionJobsTableRow}
-			headCells={headCells}
 			selectedStatus={selectedStatus}
 			selectedCreatedTime={selectedCreatedTime}
 			setSelectedStatus={setSelectedStatus}
 			setSelectedCreatedTime={setSelectedCreatedTime}
-			handleRefresh={handleRefresh}
 			fileId={fileId}
 			datasetId={datasetId}
 		/>

--- a/frontend/src/components/listeners/ExtractionHistoryTab.tsx
+++ b/frontend/src/components/listeners/ExtractionHistoryTab.tsx
@@ -143,6 +143,8 @@ export const ExtractionHistoryTab = (props): JSX.Element => {
 			setSelectedStatus={setSelectedStatus}
 			setSelectedCreatedTime={setSelectedCreatedTime}
 			handleRefresh={handleRefresh}
+			fileId={fileId}
+			datasetId={datasetId}
 		/>
 	);
 };

--- a/frontend/src/components/listeners/ExtractionJobs.tsx
+++ b/frontend/src/components/listeners/ExtractionJobs.tsx
@@ -195,33 +195,6 @@ export const ExtractionJobs = (props) => {
 	const [rows, setRows] = useState([]);
 
 	useEffect(() => {
-		// reset to first currPageNum
-		setCurrPageNum(1);
-		listListenerJobs(null, null, null, null, null, null, 0, limit);
-	}, [adminMode]);
-
-	useEffect(() => {
-		// reset to first currPageNum
-		setCurrPageNum(1);
-		if (selectedExtractor) {
-			listListenerJobs(
-				selectedExtractor["name"],
-				null,
-				null,
-				null,
-				null,
-				null,
-				0,
-				limit
-			);
-			// clear filters
-			setSelectedStatus(null);
-			setSelectedCreatedTime(null);
-		}
-	}, [selectedExtractor]);
-
-	useEffect(() => {
-		// reset to first currPageNum
 		setCurrPageNum(1);
 		listListenerJobs(
 			selectedExtractor ? selectedExtractor["name"] : null,
@@ -233,7 +206,14 @@ export const ExtractionJobs = (props) => {
 			0,
 			limit
 		);
-	}, [selectedStatus, selectedCreatedTime]);
+	}, [
+		adminMode,
+		selectedExtractor,
+		selectedStatus,
+		selectedCreatedTime,
+		limit,
+		dispatch,
+	]);
 
 	useEffect(() => {
 		const rows = [];

--- a/frontend/src/components/listeners/ExtractionJobs.tsx
+++ b/frontend/src/components/listeners/ExtractionJobs.tsx
@@ -60,7 +60,7 @@ const headCells = [
 	},
 	{
 		id: "created",
-		label: "Submitted At",
+		label: "Submitted On",
 	},
 	{
 		id: "creator",

--- a/frontend/src/components/listeners/ExtractionJobs.tsx
+++ b/frontend/src/components/listeners/ExtractionJobs.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChangeEvent, useEffect, useState } from "react";
+import { ChangeEvent, useEffect } from "react";
 import Box from "@mui/material/Box";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -169,7 +169,6 @@ export const ExtractionJobs = (props) => {
 	const [limit, setLimit] = React.useState(config.defaultExtractionJobs);
 	const [openExtractorPane, setOpenExtractorPane] = React.useState(false);
 	const [jobId, setJobId] = React.useState("");
-	const [rows, setRows] = useState([]);
 
 	useEffect(() => {
 		setCurrPageNum(1);
@@ -276,7 +275,7 @@ export const ExtractionJobs = (props) => {
 				</Dialog>
 				<TableContainer>
 					<ExtractionJobsToolbar
-						numExecution={rows.length}
+						numExecution={jobs.length}
 						selectedStatus={selectedStatus}
 						selectedCreatedTime={selectedCreatedTime}
 						setSelectedStatus={setSelectedStatus}

--- a/frontend/src/components/listeners/ExtractionJobs.tsx
+++ b/frontend/src/components/listeners/ExtractionJobs.tsx
@@ -197,8 +197,8 @@ export const ExtractionJobs = (props) => {
 			selectedExtractor ? selectedExtractor["name"] : null,
 			selectedStatus,
 			null,
-			null,
-			null,
+			fileId ? fileId : null,
+			datasetId ? datasetId : null,
 			selectedCreatedTime ? format(selectedCreatedTime, "yyyy-MM-dd") : null,
 			(currPageNum - 1) * limit,
 			limit
@@ -221,8 +221,8 @@ export const ExtractionJobs = (props) => {
 			selectedExtractor ? selectedExtractor["name"] : null,
 			selectedStatus ? selectedStatus : null,
 			null,
-			null,
-			null,
+			fileId ? fileId : null,
+			datasetId ? datasetId : null,
 			selectedCreatedTime ? format(selectedCreatedTime, "yyyy-MM-dd") : null,
 			newSkip,
 			limit
@@ -241,8 +241,8 @@ export const ExtractionJobs = (props) => {
 			selectedExtractor ? selectedExtractor["name"] : null,
 			selectedStatus ? selectedStatus : null,
 			null,
-			null,
-			null,
+			fileId ? fileId : null,
+			datasetId ? datasetId : null,
 			selectedCreatedTime ? format(selectedCreatedTime, "yyyy-MM-dd") : null,
 			0,
 			newRowsPerPage

--- a/frontend/src/components/listeners/ExtractionJobs.tsx
+++ b/frontend/src/components/listeners/ExtractionJobs.tsx
@@ -342,9 +342,7 @@ export const ExtractionJobs = (props) => {
 										<TableCell align="left">{job.listener_id}</TableCell>
 										<TableCell align="left">{parseDate(job.created)}</TableCell>
 										<TableCell align="left">{job.creator.email}</TableCell>
-										<TableCell align="left">
-											{job.duration ? `${job.duration}seconds` : "waiting..."}
-										</TableCell>
+										<TableCell align="left">{job.duration} seconds</TableCell>
 										<TableCell align="left">
 											{job.resource_ref.collection}
 										</TableCell>

--- a/frontend/src/components/listeners/ExtractionJobs.tsx
+++ b/frontend/src/components/listeners/ExtractionJobs.tsx
@@ -33,7 +33,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../types/data";
 import { format } from "date-fns";
 import { parseDate } from "../../utils/common";
-import { EventListenerJobOut } from "../../openapi/v2";
 
 export interface Data {
 	status: string;
@@ -80,28 +79,6 @@ const headCells = [
 		label: "Resource Id",
 	},
 ];
-
-const createData = (
-	status: string,
-	jobId: string,
-	listenerName: string,
-	created: string,
-	creator: string,
-	duration: number,
-	resourceType: string,
-	resourceId: string
-) => {
-	return {
-		status,
-		jobId,
-		listenerName,
-		created,
-		creator,
-		duration,
-		resourceType,
-		resourceId,
-	};
-};
 
 function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
 	if (b[orderBy] < a[orderBy]) {
@@ -215,27 +192,6 @@ export const ExtractionJobs = (props) => {
 		dispatch,
 	]);
 
-	useEffect(() => {
-		const rows = [];
-		if (jobs && jobs.length > 0) {
-			jobs.map((job: EventListenerJobOut) => {
-				rows.push(
-					createData(
-						job["status"],
-						job["id"],
-						job["listener_id"],
-						parseDate(job["created"]),
-						job["creator"]["email"],
-						`${job["duration"]} sec`,
-						job["resource_ref"]["collection"],
-						job["resource_ref"]["resource_id"]
-					)
-				);
-			});
-		}
-		setRows(rows);
-	}, [jobs]);
-
 	const handleRefresh = () => {
 		listListenerJobs(
 			selectedExtractor ? selectedExtractor["name"] : null,
@@ -339,35 +295,35 @@ export const ExtractionJobs = (props) => {
 							headCells={headCells}
 						/>
 						<TableBody>
-							{stableSort(rows, getComparator(order, orderBy)).map((row) => {
+							{stableSort(jobs, getComparator(order, orderBy)).map((job) => {
 								return (
-									<TableRow key={row.jobId}>
+									<TableRow key={job.id}>
 										<TableCell
 											align="right"
 											sx={{ color: theme.palette.primary.main }}
 										>
-											{row.status === config.eventListenerJobStatus.created ? (
+											{job.status === config.eventListenerJobStatus.created ? (
 												<AddCircleOutlineIcon />
 											) : null}
-											{row.status ===
+											{job.status ===
 											config.eventListenerJobStatus.resubmitted ? (
 												<RestartAltIcon />
 											) : null}
-											{row.status === config.eventListenerJobStatus.started ? (
+											{job.status === config.eventListenerJobStatus.started ? (
 												<PlayCircleOutlineIcon />
 											) : null}
-											{row.status ===
+											{job.status ===
 											config.eventListenerJobStatus.processing ? (
 												<AccessTimeIcon />
 											) : null}
-											{row.status ===
+											{job.status ===
 											config.eventListenerJobStatus.succeeded ? (
 												<CheckCircleIcon />
 											) : null}
-											{row.status === config.eventListenerJobStatus.error ? (
+											{job.status === config.eventListenerJobStatus.error ? (
 												<CancelIcon />
 											) : null}
-											{row.status === config.eventListenerJobStatus.skipped ? (
+											{job.status === config.eventListenerJobStatus.skipped ? (
 												<SkipNextIcon />
 											) : null}
 										</TableCell>
@@ -376,19 +332,25 @@ export const ExtractionJobs = (props) => {
 												component="button"
 												variant="body2"
 												onClick={() => {
-													setJobId(row.jobId);
+													setJobId(job.id);
 													handleExtractionSummary();
 												}}
 											>
-												{row.jobId}
+												{job.id}
 											</Link>
 										</TableCell>
-										<TableCell align="left">{row.listenerName}</TableCell>
-										<TableCell align="left">{row.created}</TableCell>
-										<TableCell align="left">{row.creator}</TableCell>
-										<TableCell align="left">{row.duration}</TableCell>
-										<TableCell align="left">{row.resourceType}</TableCell>
-										<TableCell align="left">{row.resourceId}</TableCell>
+										<TableCell align="left">{job.listener_id}</TableCell>
+										<TableCell align="left">{parseDate(job.created)}</TableCell>
+										<TableCell align="left">{job.creator.email}</TableCell>
+										<TableCell align="left">
+											{job.duration ? `${job.duration}seconds` : "waiting..."}
+										</TableCell>
+										<TableCell align="left">
+											{job.resource_ref.collection}
+										</TableCell>
+										<TableCell align="left">
+											{job.resource_ref.resource_id}
+										</TableCell>
 									</TableRow>
 								);
 							})}

--- a/frontend/src/components/listeners/ExtractionJobs.tsx
+++ b/frontend/src/components/listeners/ExtractionJobs.tsx
@@ -371,26 +371,24 @@ export const ExtractionJobs = (props) => {
 												<SkipNextIcon />
 											) : null}
 										</TableCell>
-										{Object.keys(row).map((key) => {
-											if (key == "jobId") {
-												return (
-													<TableCell align="left">
-														<Link
-															component="button"
-															variant="body2"
-															onClick={() => {
-																setJobId(row[key]);
-																handleExtractionSummary();
-															}}
-														>
-															{row[key]}
-														</Link>
-													</TableCell>
-												);
-											}
-											if (key !== "status")
-												return <TableCell align="left">{row[key]}</TableCell>;
-										})}
+										<TableCell align="left">
+											<Link
+												component="button"
+												variant="body2"
+												onClick={() => {
+													setJobId(row.jobId);
+													handleExtractionSummary();
+												}}
+											>
+												{row.jobId}
+											</Link>
+										</TableCell>
+										<TableCell align="left">{row.listenerName}</TableCell>
+										<TableCell align="left">{row.created}</TableCell>
+										<TableCell align="left">{row.creator}</TableCell>
+										<TableCell align="left">{row.duration}</TableCell>
+										<TableCell align="left">{row.resourceType}</TableCell>
+										<TableCell align="left">{row.resourceId}</TableCell>
 									</TableRow>
 								);
 							})}

--- a/frontend/src/components/listeners/ExtractionJobs.tsx
+++ b/frontend/src/components/listeners/ExtractionJobs.tsx
@@ -151,6 +151,8 @@ export const ExtractionJobs = (props) => {
 		setSelectedStatus,
 		setSelectedCreatedTime,
 		selectedExtractor,
+		fileId,
+		datasetId,
 	} = props;
 
 	const dispatch = useDispatch();
@@ -225,8 +227,8 @@ export const ExtractionJobs = (props) => {
 			selectedExtractor ? selectedExtractor["name"] : null,
 			selectedStatus,
 			null,
-			null,
-			null,
+			fileId ? fileId : null,
+			datasetId ? datasetId : null,
 			selectedCreatedTime ? format(selectedCreatedTime, "yyyy-MM-dd") : null,
 			0,
 			limit

--- a/frontend/src/components/listeners/ExtractionJobsToolbar.tsx
+++ b/frontend/src/components/listeners/ExtractionJobsToolbar.tsx
@@ -72,7 +72,7 @@ export const ExtractionJobsToolbar = (props: ExtractionJobsToolbarProps) => {
 				</FormControl>
 				<LocalizationProvider dateAdapter={AdapterDateFns}>
 					<DatePicker
-						label="Submitted at"
+						label="Submitted on"
 						value={selectedCreatedTime}
 						onChange={(value) => {
 							setSelectedCreatedTime(value);

--- a/frontend/src/components/visualizations/PublicVisualization.tsx
+++ b/frontend/src/components/visualizations/PublicVisualization.tsx
@@ -111,7 +111,9 @@ export const PublicVisualization = (props: previewProps) => {
 			{/* 1. load all the visualization components and its definition available to the frontend */}
 			{visComponentDefinitions.map((visComponentDefinition) => {
 				return (
-					<LazyLoadErrorBoundary fallback={<div>Fail to load...</div>}>
+					<LazyLoadErrorBoundary
+						fallback={<div>Visualization failed to load...</div>}
+					>
 						<Suspense fallback={<div>Loading...</div>}>
 							{(() => {
 								// 2. looking for visualization configuration registered for this resource

--- a/frontend/src/components/visualizations/Visualization.tsx
+++ b/frontend/src/components/visualizations/Visualization.tsx
@@ -107,7 +107,9 @@ export const Visualization = (props: previewProps) => {
 			{/* 1. load all the visualization components and its definition available to the frontend */}
 			{visComponentDefinitions.map((visComponentDefinition) => {
 				return (
-					<LazyLoadErrorBoundary fallback={<div>Fail to load...</div>}>
+					<LazyLoadErrorBoundary
+						fallback={<div>Visualization failed to load...</div>}
+					>
 						<Suspense fallback={<div>Loading...</div>}>
 							{(() => {
 								// 2. looking for visualization configuration registered for this resource


### PR DESCRIPTION
Several fixes required for beta-3 release, mostly in the listing of extractor events. This also cleans up a lot of code and combines useEffects calls in one call instead of many. Now the list of extraction events should be scoped to the dataset or file id currently being looked at, instead of showing all events. Also worth noticing, extraction messages were not working due to a change in imports. Please see comments on commits for a full list.