### PR TITLE
Fix refresh token issue when using password flow

### DIFF
--- a/backend/app/routers/authentication.py
+++ b/backend/app/routers/authentication.py
@@ -8,6 +8,7 @@ from app.keycloak_auth import (
 )
 from app.models.datasets import DatasetDBViewList
 from app.models.users import UserDB, UserIn, UserLogin, UserOut
+from app.routers.utils import save_refresh_token
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException
 from keycloak.exceptions import (
@@ -65,10 +66,11 @@ async def save_user(userIn: UserIn):
     return user.dict()
 
 
-@router.post("/login", deprecated=True)
+@router.post("/login")
 async def login(userIn: UserLogin):
     try:
         token = keycloak_openid.token(userIn.email, userIn.password)
+        await save_refresh_token(token["refresh_token"], userIn.email)
         return {"token": token["access_token"]}
     # bad credentials
     except KeycloakAuthenticationError as e:

--- a/backend/app/routers/authentication.py
+++ b/backend/app/routers/authentication.py
@@ -65,7 +65,7 @@ async def save_user(userIn: UserIn):
     return user.dict()
 
 
-@router.post("/login")
+@router.post("/login", deprecated=True)
 async def login(userIn: UserLogin):
     try:
         token = keycloak_openid.token(userIn.email, userIn.password)

--- a/backend/app/routers/keycloak.py
+++ b/backend/app/routers/keycloak.py
@@ -12,6 +12,7 @@ from app.keycloak_auth import (
 )
 from app.models.tokens import TokenDB
 from app.models.users import UserDB, UserLogin
+from app.routers.utils import save_refresh_token
 from fastapi import APIRouter, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import ExpiredSignatureError, JWTError, jwt
@@ -84,18 +85,7 @@ async def loginPost(userIn: UserLogin):
     """Client can use this to login when redirect is not available."""
     try:
         token = keycloak_openid.token(userIn.email, userIn.password)
-
-        # store/update refresh token and link to that userid
-        token_exist = await TokenDB.find_one(TokenDB.email == userIn.email)
-        if token_exist is not None:
-            token_exist.refresh_token = token["refresh_token"]
-            await token_exist.save()
-        else:
-            token_created = TokenDB(
-                email=userIn.email, refresh_token=token["refresh_token"]
-            )
-            await token_created.insert()
-
+        await save_refresh_token(token["refresh_token"], userIn.email)
         return {"token": token["access_token"]}
     # bad credentials
     except KeycloakAuthenticationError as e:

--- a/backend/app/routers/keycloak.py
+++ b/backend/app/routers/keycloak.py
@@ -91,7 +91,9 @@ async def loginPost(userIn: UserLogin):
             token_exist.refresh_token = token["refresh_token"]
             await token_exist.save()
         else:
-            token_created = TokenDB(email=userIn.email, refresh_token=token["refresh_token"])
+            token_created = TokenDB(
+                email=userIn.email, refresh_token=token["refresh_token"]
+            )
             await token_created.insert()
 
         return {"token": token["access_token"]}

--- a/backend/app/routers/utils.py
+++ b/backend/app/routers/utils.py
@@ -2,6 +2,7 @@ import mimetypes
 from typing import Optional
 
 from app.models.files import ContentType
+from app.models.tokens import TokenDB
 
 
 def get_content_type(
@@ -23,3 +24,14 @@ def get_content_type(
             content_type = "application/octet-stream"
     type_main = content_type.split("/")[0] if type(content_type) is str else "N/A"
     return ContentType(content_type=content_type, main_type=type_main)
+
+
+async def save_refresh_token(refresh_token: str, email: str):
+    """Store/update refresh token and link to that userid."""
+    token_exist = await TokenDB.find_one(TokenDB.email == email)
+    if token_exist is not None:
+        token_exist.refresh_token = refresh_token
+        await token_exist.save()
+    else:
+        token_created = TokenDB(email=email, refresh_token=refresh_token)
+        await token_created.insert()

--- a/frontend/src/openapi/v2/services/AuthService.ts
+++ b/frontend/src/openapi/v2/services/AuthService.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { UserIn } from '../models/UserIn';
+import type { UserLogin } from '../models/UserLogin';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { request as __request } from '../core/request';
 
@@ -40,7 +40,7 @@ export class AuthService {
      * @throws ApiError
      */
     public static loginPostApiV2AuthLoginPost(
-        requestBody: UserIn,
+        requestBody: UserLogin,
     ): CancelablePromise<any> {
         return __request({
             method: 'POST',

--- a/frontend/src/openapi/v2/services/LoginService.ts
+++ b/frontend/src/openapi/v2/services/LoginService.ts
@@ -30,6 +30,7 @@ export class LoginService {
     }
 
     /**
+     * @deprecated
      * Login
      * @param requestBody
      * @returns any Successful Response

--- a/frontend/src/openapi/v2/services/LoginService.ts
+++ b/frontend/src/openapi/v2/services/LoginService.ts
@@ -30,7 +30,6 @@ export class LoginService {
     }
 
     /**
-     * @deprecated
      * Login
      * @param requestBody
      * @returns any Successful Response

--- a/openapi.json
+++ b/openapi.json
@@ -153,7 +153,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/api/v2/users/me/is_admin": {
@@ -11912,7 +11913,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UserIn"
+                "$ref": "#/components/schemas/UserLogin"
               }
             }
           },

--- a/openapi.json
+++ b/openapi.json
@@ -153,8 +153,7 @@
               }
             }
           }
-        },
-        "deprecated": true
+        }
       }
     },
     "/api/v2/users/me/is_admin": {


### PR DESCRIPTION
- Related:  ncsa/idot-pma#173
- `POST /login` and `POST /auth/login` have the exact same logic. @longshuicy suggested deprecating the `POST /login` endpoint.
- Applied the same logic for refresh tokens as used in the authorization code flow (`GET /auth`) so that access tokens obtained through the password flow (`POST /auth/login`) can also be refreshed by `GET /auth/refresh_token`.
