### PR TITLE
Use healthcheck to make sure elasticsearch has

### DIFF
--- a/docker-compose.extractors.yml
+++ b/docker-compose.extractors.yml
@@ -1,6 +1,5 @@
 version: '3.7'
 
-
 services:
   name-entity-recognition:
     image: socialmediamacroscope/name_entity_recognition_extractor:latest
@@ -40,15 +39,6 @@ services:
 
   sentiment-analysis:
     image: socialmediamacroscope/sentiment_analysis_extractor:latest
-    environment:
-      CLOWDER_VERSION: 2
-      RABBITMQ_URI: amqp://guest:guest@rabbitmq:5672/%2F
-    networks:
-      - clowder2
-    restart: unless-stopped
-
-  wordcount:
-    image: clowder/extractors-wordcount:latest
     environment:
       CLOWDER_VERSION: 2
       RABBITMQ_URI: amqp://guest:guest@rabbitmq:5672/%2F

--- a/docker-compose.previewers.yml
+++ b/docker-compose.previewers.yml
@@ -1,21 +1,5 @@
 version: '3.7'
 
-# Settings and configurations that are common for all containers
-x-minio-common: &minio-common
-  image: quay.io/minio/minio:RELEASE.2022-01-25T19-56-04Z
-  command: server --console-address ":9001" http://minio{1...4}/data
-  expose:
-    - "9000"
-    - "9001"
-  environment:
-    MINIO_ROOT_USER: minioadmin
-    MINIO_ROOT_PASSWORD: minioadmin
-  healthcheck:
-    test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
-    interval: 30s
-    timeout: 20s
-    retries: 3
-
 services:
 
   geoserver:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,11 +64,16 @@ services:
       keycloak_base: http://localhost/api
       frontend_url: http://localhost
     depends_on:
-      - mongo
-      - minio-nginx
-      - keycloak
-      - elasticsearch
-      - rabbitmq
+      mongo:
+        condition: service_started
+      minio-nginx:
+        condition: service_started
+      keycloak:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_started
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.backend.rule=PathPrefix(`/api`)"
@@ -245,6 +250,8 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.3.3
     restart: unless-stopped
+    healthcheck:
+      test: "curl -f http://localhost:9200/_cluster/health?wait_for_status=yellow"
     networks:
       - clowder2
     environment:


### PR DESCRIPTION
started before starting backend.

Backend used to fail with docker compose prod.