### PR TITLE
Add conditional checks to handle secret keys

### DIFF
--- a/deployments/kubernetes/charts/clowder2/ibm-hpc.yaml
+++ b/deployments/kubernetes/charts/clowder2/ibm-hpc.yaml
@@ -1,0 +1,86 @@
+hostname: &hostname ibmclowder.software-dev.ncsa.illinois.edu
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  tls:
+    - hosts:
+      - *hostname
+      secretName: clowder2-tls
+
+
+geoserver:
+  enabled: false
+
+minio:
+  auth:
+    rootUser: clowder
+    rootPassword: ilikecats
+  persistence:
+    storageClass: nfs-taiga
+    size: 20Gi
+  ingress:
+    enabled: true
+    hostname: minio.ibmclowder.software-dev.ncsa.illinois.edu
+  apiIngress:
+    enabled: true
+    hostname: minio-api.ibmclowder.software-dev.ncsa.illinois.edu
+
+rabbitmq:
+  # login
+  auth:
+    username: guest
+    password: ilikecats
+    erlangCookie: kittencookie
+  ingress:
+    enabled: true
+    hostname: rabbitmq.ibmclowder.software-dev.ncsa.illinois.edu
+  persistence:
+    storageClass: csi-cinder-sc-delete
+    size: 8Gi
+
+mongodb:
+  persistence:
+    storageClass: csi-cinder-sc-delete
+    size: 8Gi
+
+elasticsearch:
+  master:
+    persistence:
+      storageClass: csi-cinder-sc-delete
+      size: 20Gi
+  data:
+    persistence:
+      storageClass: csi-cinder-sc-delete
+      size: 20Gi
+
+keycloak:
+  auth:
+    adminUser: guest
+    adminPassword: ilikecats
+  ingress:
+    hostname: ibmclowder.software-dev.ncsa.illinois.edu
+  postgresql:
+    auth:
+      password: cGFzc3dvcmQ=
+      postgresPassword: Nm50T2lJR05sZQ==
+    primary:
+      persistence:
+        storageClass: csi-cinder-sc-delete
+        size: 8Gi
+
+message:
+  image:
+    repository: clowder/clowder2-messages
+    tag: release-v2.0-beta-3
+
+heartbeat:
+  image:
+    repository: clowder/clowder2-heartbeat
+    tag: release-v2.0-beta-3
+
+extractors:
+  wordcount:
+    enabled: true
+    image: clowder/extractors-wordcount:latest

--- a/deployments/kubernetes/charts/clowder2/ibm-hpc.yaml
+++ b/deployments/kubernetes/charts/clowder2/ibm-hpc.yaml
@@ -84,3 +84,13 @@ extractors:
   wordcount:
     enabled: true
     image: clowder/extractors-wordcount:latest
+  rcnn-iwp-inference:
+    enabled: true
+    image: vismayak/rcnn_iwp_inference_extractor_k8:latest
+    volumes:
+      - name: minio-storage
+        hostPath:
+          path: /mnt/ibm-hpc-clowderfs
+    volumeMounts:
+      - name: minio-storage
+        mountPath: /clowderfs

--- a/deployments/kubernetes/charts/clowder2/ibm-hpc.yaml
+++ b/deployments/kubernetes/charts/clowder2/ibm-hpc.yaml
@@ -25,7 +25,12 @@ minio:
     hostname: minio.ibmclowder.software-dev.ncsa.illinois.edu
   apiIngress:
     enabled: true
-    hostname: minio-api.ibmclowder.software-dev.ncsa.illinois.edu
+    hostname: minio.ibmclowder.software-dev.ncsa.illinois.edu
+
+frontend:
+  image:
+    repository: vismayak/clowder-frontend
+    tag: latest
 
 rabbitmq:
   # login
@@ -87,6 +92,22 @@ extractors:
   rcnn-iwp-inference:
     enabled: true
     image: vismayak/rcnn_iwp_inference_extractor_k8:latest
+    env:
+      - name: MINIO_MOUNTED_PATH
+        value: /clowderfs
+    volumes:
+      - name: minio-storage
+        hostPath:
+          path: /mnt/ibm-hpc-clowderfs
+    volumeMounts:
+      - name: minio-storage
+        mountPath: /clowderfs
+  rcnn-iwp-finetuning:
+    enabled: true
+    image: vismayak/rcnn_iwp_finetuning_extractor_k8:latest
+    env:
+      - name: MINIO_MOUNTED_PATH
+        value: /clowderfs
     volumes:
       - name: minio-storage
         hostPath:

--- a/deployments/kubernetes/charts/clowder2/minio-credentials.yaml
+++ b/deployments/kubernetes/charts/clowder2/minio-credentials.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: ibm-hpc
+stringData:
+  MINIO_ENDPOINT: http://clowder2-minio:9000
+  MINIO_ACCESS_KEY: clowder
+  MINIO_SECRET_KEY: ilikecats
+  MINIO_MOUNT_POINT: /var/clowderfs
+  CLOWDER_VERSION: "2"
+

--- a/deployments/kubernetes/charts/clowder2/minio-daemonset.yaml
+++ b/deployments/kubernetes/charts/clowder2/minio-daemonset.yaml
@@ -37,4 +37,5 @@ spec:
             path: /dev/fuse
         - name: minio-point
           hostPath:
-            path: /mnt/clowderfs
+            path: /mnt/ibm-hpc-clowderfs
+            type: DirectoryOrCreate

--- a/deployments/kubernetes/charts/clowder2/minio-daemonset.yaml
+++ b/deployments/kubernetes/charts/clowder2/minio-daemonset.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: minio-mounter
+  namespace: ibm-hpc
+  labels:
+    app: minio-mounter
+spec:
+  selector:
+    matchLabels:
+      app: minio-mounter
+  template:
+    metadata:
+      labels:
+        app: minio-mounter
+    spec:
+      containers:
+        - name: minio-fuse
+          image: vismayak/minio-mount-daemon-container
+          securityContext:
+            privileged: true
+          envFrom:
+            - secretRef:
+                name: minio-credentials
+          volumeMounts:
+            - name: fuse
+              mountPath: /dev/fuse
+            - name: minio-point
+              mountPath: /var/clowderfs:shared
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "fusermount -u /var/clowderfs"]
+      volumes:
+        - name: fuse
+          hostPath:
+            path: /dev/fuse
+        - name: minio-point
+          hostPath:
+            path: /mnt/clowderfs

--- a/deployments/kubernetes/charts/clowder2/minio-test-pod.yaml
+++ b/deployments/kubernetes/charts/clowder2/minio-test-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minio-test-pod
+spec:
+  containers:
+  - name: minio-test-pod
+    image: alpine
+    command: [ "sleep", "infinity" ]
+    volumeMounts:
+      - name: minio-storage
+        mountPath: /clowderfs
+  volumes:
+  - name: minio-storage
+    hostPath:
+      path: /mnt/clowderfs

--- a/deployments/kubernetes/charts/clowder2/minio-test-pod.yaml
+++ b/deployments/kubernetes/charts/clowder2/minio-test-pod.yaml
@@ -13,4 +13,4 @@ spec:
   volumes:
   - name: minio-storage
     hostPath:
-      path: /mnt/clowderfs
+      path: /mnt/ibm-hpc-clowderfs

--- a/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
@@ -54,11 +54,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.backend.existingSecret }}
                   key: {{ .Values.backend.existingMinioSecretKey | default "root-password" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{include "clowder2.releaseName" . }}-secret
                   key: root-password
+              {{- else }}
+              value: {{ .Values.minio.auth.rootPassword }}
               {{- end }}
             - name: MINIO_UPLOAD_CHUNK_SIZE
               value: "10485760"

--- a/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
@@ -106,11 +106,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.backend.existingSecret }}
                   key: {{ .Values.backend.existingRabbitMQSecretKey | default "rabbitmq-password" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "clowder2.releaseName" . }}-secret
                   key: rabbitmq-password
+              {{- else }}
+              value: {{ .Values.rabbitmq.auth.password }}
               {{- end }}
             - name: RABBITMQ_HOST
               value: {{ include "clowder2.releaseName" .  }}-rabbitmq

--- a/deployments/kubernetes/charts/clowder2/templates/extractors/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/extractors/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .volumes }}
+      volumes:
+        {{- toYaml .volumes | nindent 8 }}
+    {{- end }}
       containers:
         - name: extractor
           image: {{ .image | quote }}
@@ -56,6 +60,10 @@ spec:
 
 {{- if .env }}
             {{- toYaml .env | nindent 12 }}
+{{- end }}
+{{- if .volumeMounts }}
+          volumeMounts:
+            {{- toYaml .volumeMounts | nindent 12 }}
 {{- end }}
 {{- if .resources }}
           resources:

--- a/deployments/kubernetes/charts/clowder2/templates/geoserver/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/geoserver/deployment.yaml
@@ -36,11 +36,13 @@ spec:
                 secretKeyRef:
                   name: {{.Values.geoserver.existingSecret }}
                   key: {{.Values.geoserver.existingGeoserverSecretKey | default "GEOSERVER_PW" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{include "clowder2.releaseName" . }}-secret
                   key: GEOSERVER_PW
+              {{- else }}
+              value: {{ .Values.geoserver.password }}
               {{- end }}
           ports:
             - containerPort: 8080

--- a/deployments/kubernetes/charts/clowder2/templates/heartbeat/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/heartbeat/deployment.yaml
@@ -43,11 +43,13 @@ spec:
                 secretKeyRef:
                   name: {{.Values.heartbeat.existingSecret }}
                   key: {{.Values.heartbeat.existingRabbitMQSecretKey | default "rabbitmq-password" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{include "clowder2.releaseName" . }}-secret
                   key: rabbitmq-password
+              {{- else }}
+              value: {{ .Values.rabbitmq.auth.password }}
               {{- end }}
             - name: RABBITMQ_HOST
               value: {{ include "clowder2.releaseName" .  }}-rabbitmq

--- a/deployments/kubernetes/charts/clowder2/templates/messages/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/messages/deployment.yaml
@@ -43,11 +43,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.message.existingSecret }}
                   key: {{ .Values.message.existingRabbitMQSecretKey | default "rabbitmq-password" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "clowder2.releaseName" . }}-secret
                   key: rabbitmq-password
+              {{- else }}
+              value: {{ .Values.rabbitmq.auth.password }}
               {{- end }}
             - name: RABBITMQ_HOST
               value: {{ include "clowder2.releaseName" .  }}-rabbitmq


### PR DESCRIPTION
The additional check if a secret file exists in kubernetes  (`<release-name>-secret`)else it uses the values file

To test, just try a dry run helm install 
`helm install --dry-run  --namespace ibm-hpc clowder2 .  > test.yaml`

Check the value of `MINIO_SECRET_KEY` under backend and value of `RABBITMQ_PASS` under heartbeat, messages and backend in test.yaml