### PR TITLE
Add conditional checks to handle secret keys

### DIFF
--- a/deployments/kubernetes/charts/clowder2/ibm-hpc.yaml
+++ b/deployments/kubernetes/charts/clowder2/ibm-hpc.yaml
@@ -1,0 +1,86 @@
+hostname: &hostname ibmclowder.software-dev.ncsa.illinois.edu
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  tls:
+    - hosts:
+      - *hostname
+      secretName: clowder2-tls
+
+
+geoserver:
+  enabled: false
+
+minio:
+  auth:
+    rootUser: clowder
+    rootPassword: ilikecats
+  persistence:
+    storageClass: nfs-taiga
+    size: 20Gi
+  ingress:
+    enabled: true
+    hostname: minio.ibmclowder.software-dev.ncsa.illinois.edu
+  apiIngress:
+    enabled: true
+    hostname: minio-api.ibmclowder.software-dev.ncsa.illinois.edu
+
+rabbitmq:
+  # login
+  auth:
+    username: guest
+    password: ilikecats
+    erlangCookie: kittencookie
+  ingress:
+    enabled: true
+    hostname: rabbitmq.ibmclowder.software-dev.ncsa.illinois.edu
+  persistence:
+    storageClass: csi-cinder-sc-delete
+    size: 8Gi
+
+mongodb:
+  persistence:
+    storageClass: csi-cinder-sc-delete
+    size: 8Gi
+
+elasticsearch:
+  master:
+    persistence:
+      storageClass: csi-cinder-sc-delete
+      size: 20Gi
+  data:
+    persistence:
+      storageClass: csi-cinder-sc-delete
+      size: 20Gi
+
+keycloak:
+  auth:
+    adminUser: guest
+    adminPassword: ilikecats
+  ingress:
+    hostname: ibmclowder.software-dev.ncsa.illinois.edu
+  postgresql:
+    auth:
+      password: cGFzc3dvcmQ=
+      postgresPassword: Nm50T2lJR05sZQ==
+    primary:
+      persistence:
+        storageClass: csi-cinder-sc-delete
+        size: 8Gi
+
+message:
+  image:
+    repository: clowder/clowder2-messages
+    tag: release-v2.0-beta-3
+
+heartbeat:
+  image:
+    repository: clowder/clowder2-heartbeat
+    tag: release-v2.0-beta-3
+
+extractors:
+  wordcount:
+    enabled: true
+    image: clowder/extractors-wordcount:latest

--- a/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
@@ -54,11 +54,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.backend.existingSecret }}
                   key: {{ .Values.backend.existingMinioSecretKey | default "root-password" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{include "clowder2.releaseName" . }}-secret
                   key: root-password
+              {{- else }}
+              value: {{ .Values.minio.auth.rootPassword }}
               {{- end }}
             - name: MINIO_UPLOAD_CHUNK_SIZE
               value: "10485760"

--- a/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/backend/deployment.yaml
@@ -106,11 +106,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.backend.existingSecret }}
                   key: {{ .Values.backend.existingRabbitMQSecretKey | default "rabbitmq-password" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "clowder2.releaseName" . }}-secret
                   key: rabbitmq-password
+              {{- else }}
+              value: {{ .Values.rabbitmq.auth.password }}
               {{- end }}
             - name: RABBITMQ_HOST
               value: {{ include "clowder2.releaseName" .  }}-rabbitmq

--- a/deployments/kubernetes/charts/clowder2/templates/geoserver/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/geoserver/deployment.yaml
@@ -36,11 +36,13 @@ spec:
                 secretKeyRef:
                   name: {{.Values.geoserver.existingSecret }}
                   key: {{.Values.geoserver.existingGeoserverSecretKey | default "GEOSERVER_PW" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{include "clowder2.releaseName" . }}-secret
                   key: GEOSERVER_PW
+              {{- else }}
+              value: {{ .Values.geoserver.password }}
               {{- end }}
           ports:
             - containerPort: 8080

--- a/deployments/kubernetes/charts/clowder2/templates/heartbeat/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/heartbeat/deployment.yaml
@@ -43,11 +43,13 @@ spec:
                 secretKeyRef:
                   name: {{.Values.heartbeat.existingSecret }}
                   key: {{.Values.heartbeat.existingRabbitMQSecretKey | default "rabbitmq-password" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{include "clowder2.releaseName" . }}-secret
                   key: rabbitmq-password
+              {{- else }}
+              value: {{ .Values.rabbitmq.auth.password }}
               {{- end }}
             - name: RABBITMQ_HOST
               value: {{ include "clowder2.releaseName" .  }}-rabbitmq

--- a/deployments/kubernetes/charts/clowder2/templates/messages/deployment.yaml
+++ b/deployments/kubernetes/charts/clowder2/templates/messages/deployment.yaml
@@ -43,11 +43,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.message.existingSecret }}
                   key: {{ .Values.message.existingRabbitMQSecretKey | default "rabbitmq-password" }}
-              {{- else }}
+              {{- else if (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "clowder2.releaseName" .))) }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "clowder2.releaseName" . }}-secret
                   key: rabbitmq-password
+              {{- else }}
+              value: {{ .Values.rabbitmq.auth.password }}
               {{- end }}
             - name: RABBITMQ_HOST
               value: {{ include "clowder2.releaseName" .  }}-rabbitmq


### PR DESCRIPTION
The additional check if a secret file exists in kubernetes (<release-name>-secret)else it uses the values file

To test, just try a dry run helm install
helm install --dry-run  --namespace ibm-hpc clowder2 .  > test.yaml

Check the value of MINIO_SECRET_KEY under backend and value of RABBITMQ_PASS under heartbeat, messages and backend in test.yaml
