### PR TITLE
specify platform and external network for docker compose

### DIFF
--- a/docker-compose.extractors.yml
+++ b/docker-compose.extractors.yml
@@ -82,3 +82,4 @@ services:
 
 networks:
   clowder2:
+    external: ${EXTERNAL:-}

--- a/docker-compose.previewers.yml
+++ b/docker-compose.previewers.yml
@@ -2,6 +2,7 @@ services:
 
   geoserver:
     image: docker.osgeo.org/geoserver:2.23.0
+    platform: ${DOCKER_PLATFORM:-}
     environment:
       JAVA_OPTS: -Xmx1536M -XX:MaxPermSize=756M
       CORS_ENABLED: true
@@ -23,6 +24,7 @@ services:
   ## THIS IS INTENDED FOR LOCAL DEVELOPMENT ONLY.
   geotiff-preview:
     image: clowder/extractors-geotiff-preview
+    platform: ${DOCKER_PLATFORM:-}
     environment:
       GEOSERVER_URL: http://geoserver:8080/geoserver/
       EXTERNAL_GEOSERVER_URL: http://localhost:8085/geoserver/
@@ -37,6 +39,7 @@ services:
 
 networks:
   clowder2:
+    external: ${EXTERNAL:-}
 
 ## By default this config uses default local driver,
 ## For custom volumes replace with volume driver configuration.

--- a/example.env
+++ b/example.env
@@ -1,0 +1,6 @@
+# .env
+# Leave empty for auto-detection, or force a specific platform
+# DOCKER_PLATFORM=linux/amd64
+# DOCKER_PLATFORM=linux/arm64
+DOCKER_PLATFORM=linux/amd64
+EXTERNAL=true


### PR DESCRIPTION
The docker compose files for the previewers needed the platform specified to run on Macs with Silicon chip. Additionally, if the previewers were started after the network clowder2 was already created, or the extractors, they need 'external: true' for the network. 

My fix was adding a .env file for values that might need to be different, along with default values. 