### PR TITLE
848 move check feed listeners to async service

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -83,6 +83,8 @@ def get_rabbitmq() -> BlockingChannel:
     logger.debug("Connecting to rabbitmq at %s", settings.RABBITMQ_HOST)
     connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
+    print(f"DEBUG: get_rabbitmq() called. Returning channel of type: {type(channel)}")
+    print(f"DEBUG: Channel object: {channel}")
     return channel
 
 

--- a/backend/app/rabbitmq/listeners.py
+++ b/backend/app/rabbitmq/listeners.py
@@ -17,10 +17,32 @@ from app.models.users import UserOut
 from app.routers.users import get_user_job_key
 from fastapi import Depends
 from pika.adapters.blocking_connection import BlockingChannel
+import aio_pika
+from aio_pika.abc import AbstractChannel
 
 
-async def create_reply_queue():
-    channel: BlockingChannel = dependencies.get_rabbitmq()
+async def create_reply_queue(channel: AbstractChannel):
+    if (config_entry := await ConfigEntryDB.find_one({"key": "instance_id"})) is not None:
+        instance_id = config_entry.value
+    else:
+        instance_id = "".join(
+            random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
+            for _ in range(10)
+        )
+        config_entry = ConfigEntryDB(key="instance_id", value=instance_id)
+        await config_entry.insert()
+
+    queue_name = f"clowder.{instance_id}"
+
+    # Use aio_pika methods instead of pika methods
+    exchange = await channel.declare_exchange("clowder", durable=True)
+    queue = await channel.declare_queue(queue_name, durable=True, exclusive=False, auto_delete=False)
+    await queue.bind(exchange)
+
+    return queue.name
+
+async def create_reply_queue(channel: BlockingChannel):
+    # channel: BlockingChannel = dependencies.get_rabbitmq()
 
     if (
         config_entry := await ConfigEntryDB.find_one({"key": "instance_id"})
@@ -52,8 +74,12 @@ async def submit_file_job(
     routing_key: str,
     parameters: dict,
     user: UserOut,
-    rabbitmq_client: BlockingChannel,
+    rabbitmq_client: AbstractChannel,
 ):
+    # print(f"DEBUG submit_file_job: Got client of type: {type(rabbitmq_client)}")
+    # if not isinstance(rabbitmq_client, BlockingChannel):
+    #     raise TypeError(f"Expected BlockingChannel, got {type(rabbitmq_client)}. This confirms a mixing issue.")
+
     # Create an entry in job history with unique ID
     job = EventListenerJobDB(
         listener_id=routing_key,
@@ -65,6 +91,7 @@ async def submit_file_job(
     )
     await job.insert()
 
+
     current_secretKey = await get_user_job_key(user.email)
     msg_body = EventListenerJobMessage(
         filename=file_out.name,
@@ -75,15 +102,20 @@ async def submit_file_job(
         job_id=str(job.id),
         parameters=parameters,
     )
-    reply_to = await create_reply_queue()
+
+    # Use aio_pika publishing
+    # Get the existing clowder exchange
+    exchange = await rabbitmq_client.get_exchange("clowder")
+    reply_to = await create_reply_queue(rabbitmq_client)
     print("RABBITMQ_CLIENT: " + str(rabbitmq_client))
-    rabbitmq_client.basic_publish(
-        exchange="",
-        routing_key=routing_key,
-        body=json.dumps(msg_body.dict(), ensure_ascii=False),
-        properties=pika.BasicProperties(
-            content_type="application/json", delivery_mode=1, reply_to=reply_to
+    await exchange.publish(
+        aio_pika.Message(
+            body=json.dumps(msg_body.dict(), ensure_ascii=False).encode('utf-8'),
+            content_type="application/json",
+            delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+            reply_to=reply_to,
         ),
+        routing_key=routing_key,
     )
     return str(job.id)
 

--- a/backend/app/rabbitmq/listeners.py
+++ b/backend/app/rabbitmq/listeners.py
@@ -41,33 +41,6 @@ async def create_reply_queue(channel: AbstractChannel):
 
     return queue.name
 
-# async def create_reply_queue(channel: BlockingChannel):
-#     # channel: BlockingChannel = dependencies.get_rabbitmq()
-#
-#     if (
-#         config_entry := await ConfigEntryDB.find_one({"key": "instance_id"})
-#     ) is not None:
-#         instance_id = config_entry.value
-#     else:
-#         # If no ID has been generated for this instance, generate a 10-digit alphanumeric identifier
-#         instance_id = "".join(
-#             random.choice(
-#                 string.ascii_uppercase + string.ascii_lowercase + string.digits
-#             )
-#             for _ in range(10)
-#         )
-#         config_entry = ConfigEntryDB(key="instance_id", value=instance_id)
-#         await config_entry.insert()
-#
-#     queue_name = "clowder.%s" % instance_id
-#     channel.exchange_declare(exchange="clowder", durable=True)
-#     result = channel.queue_declare(
-#         queue=queue_name, durable=True, exclusive=False, auto_delete=False
-#     )
-#     queue_name = result.method.queue
-#     channel.queue_bind(exchange="clowder", queue=queue_name)
-#     return queue_name
-
 
 async def submit_file_job(
     file_out: FileOut,
@@ -102,7 +75,6 @@ async def submit_file_job(
 
     # Use aio_pika publishing
     # Get the existing clowder exchange
-    exchange = await rabbitmq_client.get_exchange("clowder")
     reply_to = await create_reply_queue(rabbitmq_client)
     print("RABBITMQ_CLIENT: " + str(rabbitmq_client))
     await rabbitmq_client.default_exchange.publish(
@@ -122,7 +94,7 @@ async def submit_dataset_job(
     routing_key: str,
     parameters: dict,
     user: UserOut,
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+    rabbitmq_client: AbstractChannel,
 ):
     # Create an entry in job history with unique ID
     job = EventListenerJobDB(
@@ -142,13 +114,14 @@ async def submit_dataset_job(
         job_id=str(job.id),
         parameters=parameters,
     )
-    reply_to = await create_reply_queue()
-    rabbitmq_client.basic_publish(
-        exchange="",
-        routing_key=routing_key,
-        body=json.dumps(msg_body.dict(), ensure_ascii=False),
-        properties=pika.BasicProperties(
-            content_type="application/json", delivery_mode=1, reply_to=reply_to
+    reply_to = await create_reply_queue(rabbitmq_client)
+    await rabbitmq_client.default_exchange.publish(
+        aio_pika.Message(
+            body=json.dumps(msg_body.dict(), ensure_ascii=False).encode('utf-8'),
+            content_type="application/json",
+            delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+            reply_to=reply_to,
         ),
+        routing_key=routing_key,
     )
     return str(job.id)

--- a/backend/app/routers/datasets.py
+++ b/backend/app/routers/datasets.py
@@ -70,6 +70,8 @@ from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPBearer
 from minio import Minio
 from pika.adapters.blocking_connection import BlockingChannel
+import aio_pika
+from aio_pika.abc import AbstractChannel
 from pymongo import DESCENDING
 from rocrate.model.person import Person
 from rocrate.rocrate import ROCrate
@@ -944,7 +946,7 @@ async def save_file(
     fs: Minio = Depends(dependencies.get_fs),
     file: UploadFile = File(...),
     es=Depends(dependencies.get_elasticsearchclient),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+    rabbitmq_client: AbstractChannel = Depends(dependencies.get_rabbitmq),
     allow: bool = Depends(Authorization("uploader")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
@@ -996,7 +998,7 @@ async def save_files(
     user=Depends(get_current_user),
     fs: Minio = Depends(dependencies.get_fs),
     es=Depends(dependencies.get_elasticsearchclient),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+    rabbitmq_client: AbstractChannel = Depends(dependencies.get_rabbitmq),
     allow: bool = Depends(Authorization("uploader")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
@@ -1056,7 +1058,7 @@ async def save_local_file(
     folder_id: Optional[str] = None,
     user=Depends(get_current_user),
     es=Depends(dependencies.get_elasticsearchclient),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+    rabbitmq_client: AbstractChannel = Depends(dependencies.get_rabbitmq),
     allow: bool = Depends(Authorization("uploader")),
 ):
     if (dataset := await DatasetDB.get(PydanticObjectId(dataset_id))) is not None:
@@ -1110,7 +1112,7 @@ async def create_dataset_from_zip(
     fs: Minio = Depends(dependencies.get_fs),
     file: UploadFile = File(...),
     es: Elasticsearch = Depends(dependencies.get_elasticsearchclient),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+    rabbitmq_client: AbstractChannel = Depends(dependencies.get_rabbitmq),
     token: str = Depends(get_token),
 ):
     if file.filename.endswith(".zip") is False:
@@ -1427,7 +1429,7 @@ async def get_dataset_extract(
     # parameters don't have a fixed model shape
     parameters: dict = None,
     user=Depends(get_current_user),
-    rabbitmq_client: BlockingChannel = Depends(dependencies.get_rabbitmq),
+    rabbitmq_client: AbstractChannel = Depends(dependencies.get_rabbitmq),
     allow: bool = Depends(Authorization("uploader")),
 ):
     if extractorName is None:

--- a/backend/app/routers/feeds.py
+++ b/backend/app/routers/feeds.py
@@ -4,7 +4,8 @@ from beanie import PydanticObjectId
 from beanie.operators import Or, RegEx
 from fastapi import APIRouter, Depends, HTTPException
 from pika.adapters.blocking_connection import BlockingChannel
-
+import aio_pika
+from aio_pika.abc import AbstractChannel
 from app.deps.authorization_deps import FeedAuthorization, ListenerAuthorization
 from app.keycloak_auth import get_current_user, get_current_username
 from app.models.feeds import FeedDB, FeedIn, FeedOut
@@ -41,7 +42,7 @@ async def check_feed_listeners(
     es_client,
     file_out: FileOut,
     user: UserOut,
-    rabbitmq_client: BlockingChannel,
+    rabbitmq_client: AbstractChannel,
 ):
     """Automatically submit new file to listeners on feeds that fit the search criteria."""
     listener_ids_found = []

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -163,12 +163,12 @@ async def add_file_entry(
     time.sleep(1)
 
     # Submit file job to any qualifying feeds
-    await check_feed_listeners(
-        es,
-        FileOut(**new_file.dict()),
-        user,
-        rabbitmq_client,
-    )
+    # await check_feed_listeners(
+    #     es,
+    #     FileOut(**new_file.dict()),
+    #     user,
+    #     rabbitmq_client,
+    # )
 
 
 async def add_local_file_entry(
@@ -205,12 +205,12 @@ async def add_local_file_entry(
     time.sleep(1)
 
     # Submit file job to any qualifying feeds
-    await check_feed_listeners(
-        es,
-        FileOut(**new_file.dict()),
-        user,
-        rabbitmq_client,
-    )
+    # await check_feed_listeners(
+    #     es,
+    #     FileOut(**new_file.dict()),
+    #     user,
+    #     rabbitmq_client,
+    # )
 
 
 # TODO: Move this to MongoDB middle layer

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -148,7 +148,8 @@ async def add_file_entry(
 
     message_body = {
         "event_type": "file_indexed",
-        "file_data": json.loads(new_file.json()),  # This handles ObjectID serialization
+        "file_data": json.loads(new_file.json()),
+        "user": json.loads(user.json()),# This handles ObjectID serialization
         "timestamp": datetime.now().isoformat()
     }
 
@@ -189,7 +190,8 @@ async def add_local_file_entry(
     # Publish a message when indexing is complete
     message_body = {
         "event_type": "file_indexed",
-        "file_data": json.loads(new_file.json()),  # This handles ObjectID serialization
+        "file_data": json.loads(new_file.json()),
+        "user": json.loads(user.json()),# This handles ObjectID serialization
         "timestamp": datetime.now().isoformat()
     }
 

--- a/backend/message_listener.py
+++ b/backend/message_listener.py
@@ -93,6 +93,9 @@ async def callback(message: AbstractIncomingMessage):
     async with message.process():
         msg = json.loads(message.body.decode("utf-8"))
 
+        if "event_type" in msg and msg["event_type"] == "file_indexed":
+            print(f"This is an event type file indexed!")
+
         job_id = msg["job_id"]
         message_str = msg["status"]
         timestamp = datetime.strptime(
@@ -222,6 +225,7 @@ async def listen_for_messages():
 
 
 if __name__ == "__main__":
+    logger.info(" Message listener starting...")
     start = datetime.now()
     while time_ran < timeout:
         try:

--- a/backend/message_listener.py
+++ b/backend/message_listener.py
@@ -95,6 +95,15 @@ async def callback(message: AbstractIncomingMessage):
 
         if "event_type" in msg and msg["event_type"] == "file_indexed":
             logger.info(f"This is an event type file indexed!")
+            msg = json.loads(message.body.decode("utf-8"))
+
+            # Convert string IDs back to PydanticObjectId if needed
+            file_data = msg.get("file_data", {})
+            if "id" in file_data and isinstance(file_data["id"], str):
+                file_data["id"] = PydanticObjectId(file_data["id"])
+
+            # Now you can create your FileOut object
+            # file_out = FileOut(**file_data)
             # TODO - process file indexed event here
         else:
             job_id = msg["job_id"]

--- a/backend/message_listener.py
+++ b/backend/message_listener.py
@@ -94,7 +94,7 @@ async def callback(message: AbstractIncomingMessage):
         msg = json.loads(message.body.decode("utf-8"))
 
         if "event_type" in msg and msg["event_type"] == "file_indexed":
-            print(f"This is an event type file indexed!")
+            logger.info(f"This is an event type file indexed!")
 
         job_id = msg["job_id"]
         message_str = msg["status"]
@@ -209,6 +209,8 @@ async def listen_for_messages():
             durable=True,
         )
         await queue.bind(exchange)
+        await queue.bind(exchange, routing_key="file_indexed_events")  # Add this line
+
 
         logger.info(f" [*] Listening to {exchange}")
         await queue.consume(

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -157,7 +157,7 @@ services:
       - rabbitmq
 
   extractors-messages:
-    image: "clowder/clowder2-messages:latest"
+    image: "clowder2-messages:test"
     build:
       dockerfile: backend/messages.Dockerfile
     environment:


### PR DESCRIPTION
This moves the listeners to an async service so that there is no longer a need for the time.sleep hack after indexing a file to get it to work.

To fix this, I used an async service and added a different type of event - a 'file indexed' event that the message_listener is listening to.

In order to make all this work, I did change the rabbitmq dependency from a blockingChannel to an AbstractChannel. I tested to make sure that files trigger extractors when added/indexed and also, that manual submission of datasets and files still works. 

To test this, do the following.

First, comment out in docker-compose.dev.yml the part related to the message_listener. 

Second, run the dependencies using docker-dev.sh up as usual. 

Third, run the message_listener using pycharm, in debug mode.

Fourth, run the backend in debug mode. Run the front end as usual.

Test the following:

Create a dataset and add a file - it should create an event that is picked up by the message_listener when the file is indexed, and this should trigger the check_feed_listeners and any extractors that should run on the file.

Also, to verify that everything extractor related works as before, manually submit files and datasets to extractors.