### PR TITLE
add user authorization using jwt groups claim

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: FastAPI",
+            "type": "debugpy",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/backend",
+            "module": "uvicorn",
+            "args": [ "app.main:app", "--host", "0.0.0.0", "--reload" ]
+        },
+        {
+            "name": "Launch via npm",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/frontend",
+            "env": {
+                "CLOWDER_REMOTE_HOSTNAME": "http://localhost:8000"
+            },
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "start"],
+            "outFiles": ["${workspaceFolder}/frontend/src"]
+        }
+    ]
+}

--- a/VSCODE.md
+++ b/VSCODE.md
@@ -1,0 +1,101 @@
+## VS Code development
+
+To run and debug the Clowder frontend and backend apps in VS Code IDE from the
+WSL Ubuntu 24.04 LTS distribution
+
+1.  Start VS Code, install the WSL (Windows Subsystem for Linux) extension,
+    then exit
+
+2.  Open Ubuntu 24.04 WSL terminal and clone the clowder2 repo
+
+    ```
+    git clone https://github.com/clowder-framework/clowder2.git
+    cd clowder2
+    ```
+
+3.  Install NPM needed for building frontend
+
+    ```
+    sudo apt install npm
+    ```
+
+4.  Install frontend dependencies
+
+    ```
+    cd frontend
+    npm install
+    cd ..
+    ```
+
+5.  Install Python version needed for backend, eg.
+
+    ```
+    wget http://www.python.org/ftp/python/3.10.19/Python-3.10.19.tgz
+    tar xzf Python-3.10.19.tgz
+    mkdir $HOME/.local/python
+    cd Python-3.10.19/
+    ./configure --prefix=$HOME/.local/python
+    make
+    make install
+    ```
+
+6.  Create a Python virtualenv and install backend dependencies
+
+    ```
+    cd clowder2
+    $HOME/.local/python/bin/python3 -m venv venv
+    . venv/bin/activate
+    pip install .
+    deactivate
+    ```
+
+7.  Start local docker dependencies
+
+    ```
+    cd clowder2
+    docker compose -f docker-compose.dev.yml -p clowder2-dev up -d
+    # to stop use
+    docker compose -p clowder2-dev down
+    ```
+
+8.  Add TCP proxy ports for forwarding Windows browser connections for the
+    frontend, backend and Keycloak to WSL
+
+    Get WSL IP address for `eth0` in WSL terminal
+
+    ```
+    ip -br a show dev eth0
+    ```
+
+    Add TCP proxy ports in PowerShell admin terminal
+
+    ```
+    netsh interface portproxy show v4tov4
+    netsh interface portproxy add v4tov4 listenport=3000 listenaddress=0.0.0.0 connectport=3000 connectaddress=<eth0_ip>
+    netsh interface portproxy add v4tov4 listenport=8000 listenaddress=0.0.0.0 connectport=8000 connectaddress=<eth0_ip>
+    netsh interface portproxy add v4tov4 listenport=8080 listenaddress=0.0.0.0 connectport=8080 connectaddress=<eth0_ip>
+    ```
+
+9.  Start VS Code from your WSL terminal
+
+    ```
+    cd clowder2
+    code .
+    ```
+
+10. Set the VS Code Python interpreter
+
+    1. Open Command Palette (Ctrl+Shift+P)
+    2. Click **Python: Select Interpreter** from list, set it to `./venv/bin/python`
+
+11. Start Clowder backend in VS Code Run and Debug view
+
+    1. Select **Python Debugger: FastAPI**
+    2. Click **Start Debugging**
+
+12. Start Clowder frontend in VS Code Run and Debug view
+
+    1. Select **Launch via npm**
+    2. Click **Start Debugging**
+
+13. Open [Clowder](http://localhost:3000/) in your Windows Edge or Chrome browser

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
     )
     auth_server_url = f"{auth_base}/keycloak/"
     auth_client_secret = ""
+    auth_role = "clowder2"
 
     # keycloak local config
     keycloak_username = "admin"

--- a/backend/app/keycloak_auth.py
+++ b/backend/app/keycloak_auth.py
@@ -62,7 +62,7 @@ async def get_token(
     if token:
         try:
             # See https://github.com/marcospereirampj/python-keycloak/issues/89
-            return keycloak_openid.decode_token(
+            payload = keycloak_openid.decode_token(
                 token,
                 key=await get_idp_public_key(),
                 options={"verify_aud": False},
@@ -85,6 +85,15 @@ async def get_token(
                 detail=str(e),
                 headers={"WWW-Authenticate": "Bearer"},
             )
+        if settings.auth_role:
+            groups: list = payload.get("groups", {})
+            if settings.auth_role not in groups:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Not authorized.",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+        return payload
 
     if api_key:
         serializer = URLSafeSerializer(settings.local_auth_secret, salt="api_key")

--- a/frontend/src/types/action.ts
+++ b/frontend/src/types/action.ts
@@ -293,6 +293,12 @@ interface NOT_FOUND_INLINE {
 	reason: string;
 }
 
+interface NOT_AUTHORIZED {
+	stack: string;
+	type: "NOT_AUTHORIZED";
+	reason: string;
+}
+
 interface RESET_FAILED {
 	type: "RESET_FAILED";
 	reason: string;
@@ -777,6 +783,7 @@ export type DataAction =
 	| FAILED_INLINE
 	| NOT_FOUND
 	| NOT_FOUND_INLINE
+	| NOT_AUTHORIZED
 	| RESET_FAILED
 	| RESET_FAILED_INLINE
 	| RESET_LOGOUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ description = """Clowder is a cloud native data management framework to support 
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "charset_normalizer==3.4.0",
     "fastapi==0.95.1",
     "pydantic==1.10.13",
     "uvicorn==0.21.1",
@@ -45,3 +46,5 @@ dev = [
 docs = [
     "mkdocs-material"
 ]
+[tool.setuptools]
+py-modules = []


### PR DESCRIPTION
Use keycloak/jwt groups claim for Clowder access control. Users without claim should have no access. Updates include
- add auth_role setting to backend config
  - to add a role, assign to users, and add groups mapper to keycloak:
    1. click Manage realms -> clowder
    2. click Realm roles -> Create role
    3. enter Role name: clowder2
    4. click User -> required user -> Role mapping
    5. click Assign role -> Realm role -> clowder2
    6. click Client scopes -> roles -> Mappers -> Add mapper -> From predefined mappers
    7. select and add the "groups" predefined mapper
- update get_token method to check jwt groups claim if auth_role is set
- add VSCODE.md for running Clowder frontend and backend in VS Code IDE

Issues
- update throws authorization error preventing users from viewing datasets, but users without claim can still create new datasets
- should also include an auth_role for clowder admin, or edit vs view

Does existing user authorization status need to be checked and updated in clowder db with the get_token call, or via authorization and/or users routers?